### PR TITLE
Standardize GraphQL query name

### DIFF
--- a/src/main/kotlin/hu/netsurf/erp/warehouse/controller/ProductController.kt
+++ b/src/main/kotlin/hu/netsurf/erp/warehouse/controller/ProductController.kt
@@ -3,9 +3,9 @@ package hu.netsurf.erp.warehouse.controller
 import hu.netsurf.erp.warehouse.model.Product
 import hu.netsurf.erp.warehouse.repository.ProductRepository
 import org.springframework.graphql.data.method.annotation.QueryMapping
-import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.RestController
 
-@Controller
+@RestController
 class ProductController(private val productRepository: ProductRepository) {
 
     @QueryMapping

--- a/src/main/kotlin/hu/netsurf/erp/warehouse/controller/ProductController.kt
+++ b/src/main/kotlin/hu/netsurf/erp/warehouse/controller/ProductController.kt
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RestController
 class ProductController(private val productRepository: ProductRepository) {
 
     @QueryMapping
-    fun getProducts(): List<Product> {
+    fun products(): List<Product> {
         return productRepository.findAll()
     }
 }

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -1,5 +1,5 @@
 type Query {
-    getProducts: [Product]
+    products: [Product]
 }
 
 type Product {


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [x] You have successfully built and run unit tests locally
- [ ] There are new or updated unit tests validating the changes

### :pencil: Description

Standarize GraphQL queries by removing "get" prefix from queries.