### PR TITLE
Fix 'createProduct' mutation

### DIFF
--- a/src/main/kotlin/hu/netsurf/erp/warehouse/service/ProductService.kt
+++ b/src/main/kotlin/hu/netsurf/erp/warehouse/service/ProductService.kt
@@ -18,7 +18,10 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
-class ProductService(private val productRepository: ProductRepository) {
+class ProductService(
+    private val productRepository: ProductRepository,
+    private val supplierService: SupplierService
+) {
     val logger: Logger = LoggerFactory.getLogger(ProductService::class.java)
 
     fun getProducts(): List<Product> {
@@ -54,7 +57,8 @@ class ProductService(private val productRepository: ProductRepository) {
         )
 
         val savedProduct = productRepository.save(product)
-        return getProduct(savedProduct.id)
+        savedProduct.supplier = supplierService.getSupplier(productInput.supplierId)
+        return savedProduct
     }
 
     fun updateProduct(product: Product): Product {

--- a/src/main/kotlin/hu/netsurf/erp/warehouse/service/ProductService.kt
+++ b/src/main/kotlin/hu/netsurf/erp/warehouse/service/ProductService.kt
@@ -20,7 +20,7 @@ import org.springframework.stereotype.Service
 @Service
 class ProductService(
     private val productRepository: ProductRepository,
-    private val supplierService: SupplierService
+    private val supplierService: SupplierService,
 ) {
     val logger: Logger = LoggerFactory.getLogger(ProductService::class.java)
 


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [x] You have successfully built and run unit tests locally
- [ ] There are new or updated unit tests validating the changes

### :pencil: Description

Populate all supplier data when creating a product and returning back to caller.