### PR TITLE
Implement validation rule for checking new password not matches with the current password in datatabase

### DIFF
--- a/src/main/kotlin/hu/netsurf/erp/usermanagement/exception/ConfirmCurrentPasswordException.kt
+++ b/src/main/kotlin/hu/netsurf/erp/usermanagement/exception/ConfirmCurrentPasswordException.kt
@@ -1,3 +1,0 @@
-package hu.netsurf.erp.usermanagement.exception
-
-class ConfirmCurrentPasswordException : Exception("A jelenlegi jelszó hibás.")

--- a/src/main/kotlin/hu/netsurf/erp/usermanagement/exception/ConfirmNewPasswordException.kt
+++ b/src/main/kotlin/hu/netsurf/erp/usermanagement/exception/ConfirmNewPasswordException.kt
@@ -1,3 +1,0 @@
-package hu.netsurf.erp.usermanagement.exception
-
-class ConfirmNewPasswordException : Exception("A jelszó megerősítése sikertelen.")

--- a/src/main/kotlin/hu/netsurf/erp/usermanagement/exception/ConfirmPasswordException.kt
+++ b/src/main/kotlin/hu/netsurf/erp/usermanagement/exception/ConfirmPasswordException.kt
@@ -1,3 +1,0 @@
-package hu.netsurf.erp.usermanagement.exception
-
-class ConfirmPasswordException : Exception("A jelszavak nem egyeznek.")

--- a/src/main/kotlin/hu/netsurf/erp/usermanagement/exception/CurrentPasswordAndPasswordInDatabaseNotMatchesException.kt
+++ b/src/main/kotlin/hu/netsurf/erp/usermanagement/exception/CurrentPasswordAndPasswordInDatabaseNotMatchesException.kt
@@ -1,0 +1,3 @@
+package hu.netsurf.erp.usermanagement.exception
+
+class CurrentPasswordAndPasswordInDatabaseNotMatchesException : Exception("A jelenlegi jelszó hibás.")

--- a/src/main/kotlin/hu/netsurf/erp/usermanagement/exception/NewPasswordAndConfirmNewPasswordNotMatchesException.kt
+++ b/src/main/kotlin/hu/netsurf/erp/usermanagement/exception/NewPasswordAndConfirmNewPasswordNotMatchesException.kt
@@ -1,0 +1,3 @@
+package hu.netsurf.erp.usermanagement.exception
+
+class NewPasswordAndConfirmNewPasswordNotMatchesException : Exception("A jelszó megerősítése sikertelen.")

--- a/src/main/kotlin/hu/netsurf/erp/usermanagement/exception/NewPasswordAndPasswordInDatabaseMatchesException.kt
+++ b/src/main/kotlin/hu/netsurf/erp/usermanagement/exception/NewPasswordAndPasswordInDatabaseMatchesException.kt
@@ -1,0 +1,3 @@
+package hu.netsurf.erp.usermanagement.exception
+
+class NewPasswordAndPasswordInDatabaseMatchesException : Exception("Nem adható meg új jelszónak a jelenlegi jelszó.")

--- a/src/main/kotlin/hu/netsurf/erp/usermanagement/exception/PasswordAndConfirmPasswordNotMatchesException.kt
+++ b/src/main/kotlin/hu/netsurf/erp/usermanagement/exception/PasswordAndConfirmPasswordNotMatchesException.kt
@@ -1,0 +1,3 @@
+package hu.netsurf.erp.usermanagement.exception
+
+class PasswordAndConfirmPasswordNotMatchesException : Exception("A jelszavak nem egyeznek.")

--- a/src/main/kotlin/hu/netsurf/erp/usermanagement/model/UpdateUserPasswordInput.kt
+++ b/src/main/kotlin/hu/netsurf/erp/usermanagement/model/UpdateUserPasswordInput.kt
@@ -14,5 +14,7 @@ data class UpdateUserPasswordInput(
 
     fun currentPasswordAndPasswordInDatabaseMatches(password: String): Boolean = currentPassword == password
 
+    fun newPasswordAndCurrentPasswordInDatabaseMatches(password: String): Boolean = newPassword == password
+
     fun newPasswordAndConfirmNewPasswordMatches(): Boolean = newPassword == confirmNewPassword
 }

--- a/src/main/kotlin/hu/netsurf/erp/usermanagement/util/UpdateUserPasswordInputValidator.kt
+++ b/src/main/kotlin/hu/netsurf/erp/usermanagement/util/UpdateUserPasswordInputValidator.kt
@@ -1,6 +1,6 @@
 ﻿package hu.netsurf.erp.usermanagement.util
 
-import hu.netsurf.erp.usermanagement.exception.ConfirmCurrentPasswordException
+import hu.netsurf.erp.usermanagement.exception.CurrentPasswordAndPasswordInDatabaseNotMatchesException
 import hu.netsurf.erp.usermanagement.exception.EmptyFieldException
 import hu.netsurf.erp.usermanagement.exception.NewPasswordAndConfirmNewPasswordNotMatchesException
 import hu.netsurf.erp.usermanagement.model.UpdateUserPasswordInput
@@ -21,7 +21,7 @@ class UpdateUserPasswordInputValidator {
         }
 
         if (!updateUserPasswordInput.currentPasswordAndPasswordInDatabaseMatches(passwordInDatabase)) {
-            throw ConfirmCurrentPasswordException()
+            throw CurrentPasswordAndPasswordInDatabaseNotMatchesException()
         }
 
         if (!updateUserPasswordInput.newPasswordAndConfirmNewPasswordMatches()) {

--- a/src/main/kotlin/hu/netsurf/erp/usermanagement/util/UpdateUserPasswordInputValidator.kt
+++ b/src/main/kotlin/hu/netsurf/erp/usermanagement/util/UpdateUserPasswordInputValidator.kt
@@ -3,6 +3,7 @@
 import hu.netsurf.erp.usermanagement.exception.CurrentPasswordAndPasswordInDatabaseNotMatchesException
 import hu.netsurf.erp.usermanagement.exception.EmptyFieldException
 import hu.netsurf.erp.usermanagement.exception.NewPasswordAndConfirmNewPasswordNotMatchesException
+import hu.netsurf.erp.usermanagement.exception.NewPasswordAndPasswordInDatabaseMatchesException
 import hu.netsurf.erp.usermanagement.model.UpdateUserPasswordInput
 import org.springframework.stereotype.Component
 
@@ -22,6 +23,10 @@ class UpdateUserPasswordInputValidator {
 
         if (!updateUserPasswordInput.currentPasswordAndPasswordInDatabaseMatches(passwordInDatabase)) {
             throw CurrentPasswordAndPasswordInDatabaseNotMatchesException()
+        }
+
+        if (updateUserPasswordInput.newPasswordAndCurrentPasswordInDatabaseMatches(passwordInDatabase)) {
+            throw NewPasswordAndPasswordInDatabaseMatchesException()
         }
 
         if (!updateUserPasswordInput.newPasswordAndConfirmNewPasswordMatches()) {

--- a/src/main/kotlin/hu/netsurf/erp/usermanagement/util/UpdateUserPasswordInputValidator.kt
+++ b/src/main/kotlin/hu/netsurf/erp/usermanagement/util/UpdateUserPasswordInputValidator.kt
@@ -1,8 +1,8 @@
 ﻿package hu.netsurf.erp.usermanagement.util
 
 import hu.netsurf.erp.usermanagement.exception.ConfirmCurrentPasswordException
-import hu.netsurf.erp.usermanagement.exception.ConfirmNewPasswordException
 import hu.netsurf.erp.usermanagement.exception.EmptyFieldException
+import hu.netsurf.erp.usermanagement.exception.NewPasswordAndConfirmNewPasswordNotMatchesException
 import hu.netsurf.erp.usermanagement.model.UpdateUserPasswordInput
 import org.springframework.stereotype.Component
 
@@ -25,7 +25,7 @@ class UpdateUserPasswordInputValidator {
         }
 
         if (!updateUserPasswordInput.newPasswordAndConfirmNewPasswordMatches()) {
-            throw ConfirmNewPasswordException()
+            throw NewPasswordAndConfirmNewPasswordNotMatchesException()
         }
     }
 }

--- a/src/main/kotlin/hu/netsurf/erp/usermanagement/util/UserInputValidator.kt
+++ b/src/main/kotlin/hu/netsurf/erp/usermanagement/util/UserInputValidator.kt
@@ -1,11 +1,11 @@
 ﻿package hu.netsurf.erp.usermanagement.util
 
-import hu.netsurf.erp.usermanagement.exception.ConfirmPasswordException
 import hu.netsurf.erp.usermanagement.exception.EmptyFieldException
 import hu.netsurf.erp.usermanagement.exception.InvalidEmailAddressFormatException
 import hu.netsurf.erp.usermanagement.exception.InvalidFirstNameFormatException
 import hu.netsurf.erp.usermanagement.exception.InvalidLastNameFormatException
 import hu.netsurf.erp.usermanagement.exception.InvalidLengthException
+import hu.netsurf.erp.usermanagement.exception.PasswordAndConfirmPasswordNotMatchesException
 import hu.netsurf.erp.usermanagement.model.UserInput
 import org.springframework.stereotype.Component
 
@@ -51,7 +51,7 @@ class UserInputValidator {
         }
 
         if (!userInput.passwordAndConfirmPasswordMatches()) {
-            throw ConfirmPasswordException()
+            throw PasswordAndConfirmPasswordNotMatchesException()
         }
     }
 }

--- a/src/test/kotlin/hu/netsurf/erp/testobject/UpdateUserPasswordInputTestObject.kt
+++ b/src/test/kotlin/hu/netsurf/erp/testobject/UpdateUserPasswordInputTestObject.kt
@@ -14,6 +14,8 @@ class UpdateUserPasswordInputTestObject {
 
         fun updateUserPasswordInput1WithInvalidCurrentPassword(): UpdateUserPasswordInput = build(currentPassword = "pAsSwOrD1")
 
+        fun updateUserPasswordInput1WithNewPasswordAndPasswordInDatabaseMatches(): UpdateUserPasswordInput = build(newPassword = "pAsSwOrD")
+
         fun updateUserPasswordInput1WithInvalidConfirmNewPassword(): UpdateUserPasswordInput = build(confirmNewPassword = "NeWpAsSwOrD1")
 
         private fun build(

--- a/src/test/kotlin/hu/netsurf/erp/usermanagement/service/UserServiceTests.kt
+++ b/src/test/kotlin/hu/netsurf/erp/usermanagement/service/UserServiceTests.kt
@@ -4,7 +4,7 @@ import hu.netsurf.erp.testobject.UpdateUserPasswordInputTestObject
 import hu.netsurf.erp.testobject.UserInputTestObject
 import hu.netsurf.erp.testobject.UserTestObject
 import hu.netsurf.erp.usermanagement.exception.ConfirmCurrentPasswordException
-import hu.netsurf.erp.usermanagement.exception.ConfirmNewPasswordException
+import hu.netsurf.erp.usermanagement.exception.NewPasswordAndConfirmNewPasswordNotMatchesException
 import hu.netsurf.erp.usermanagement.exception.UserNotFoundException
 import hu.netsurf.erp.usermanagement.repository.UserRepository
 import hu.netsurf.erp.usermanagement.util.UpdateUserPasswordInputSanitizer
@@ -107,15 +107,15 @@ class UserServiceTests {
     }
 
     @Test
-    fun `updateUserPassword test unhappy path - new password and confirm password not matches`() {
+    fun `updateUserPassword test unhappy path - new password and confirm new password not matches`() {
         every {
             userRepository.findById(any())
         } returns Optional.of(UserTestObject.user1())
         every {
             updateUserPasswordInputValidator.validate(any(), any())
-        } throws ConfirmNewPasswordException()
+        } throws NewPasswordAndConfirmNewPasswordNotMatchesException()
 
-        assertThrows<ConfirmNewPasswordException> {
+        assertThrows<NewPasswordAndConfirmNewPasswordNotMatchesException> {
             userService.updateUserPassword(UpdateUserPasswordInputTestObject.updateUserPasswordInput1WithInvalidConfirmNewPassword())
         }
     }

--- a/src/test/kotlin/hu/netsurf/erp/usermanagement/service/UserServiceTests.kt
+++ b/src/test/kotlin/hu/netsurf/erp/usermanagement/service/UserServiceTests.kt
@@ -3,7 +3,7 @@ package hu.netsurf.erp.usermanagement.service
 import hu.netsurf.erp.testobject.UpdateUserPasswordInputTestObject
 import hu.netsurf.erp.testobject.UserInputTestObject
 import hu.netsurf.erp.testobject.UserTestObject
-import hu.netsurf.erp.usermanagement.exception.ConfirmCurrentPasswordException
+import hu.netsurf.erp.usermanagement.exception.CurrentPasswordAndPasswordInDatabaseNotMatchesException
 import hu.netsurf.erp.usermanagement.exception.NewPasswordAndConfirmNewPasswordNotMatchesException
 import hu.netsurf.erp.usermanagement.exception.UserNotFoundException
 import hu.netsurf.erp.usermanagement.repository.UserRepository
@@ -93,15 +93,15 @@ class UserServiceTests {
     }
 
     @Test
-    fun `updateUserPassword test unhappy path - user current password not matches with the one in database`() {
+    fun `updateUserPassword test unhappy path - current password and password in database not matches`() {
         every {
             userRepository.findById(any())
         } returns Optional.of(UserTestObject.user1())
         every {
             updateUserPasswordInputValidator.validate(any(), any())
-        } throws ConfirmCurrentPasswordException()
+        } throws CurrentPasswordAndPasswordInDatabaseNotMatchesException()
 
-        assertThrows<ConfirmCurrentPasswordException> {
+        assertThrows<CurrentPasswordAndPasswordInDatabaseNotMatchesException> {
             userService.updateUserPassword(UpdateUserPasswordInputTestObject.updateUserPasswordInput1WithInvalidCurrentPassword())
         }
     }

--- a/src/test/kotlin/hu/netsurf/erp/usermanagement/util/UpdateUserPasswordInputValidatorTests.kt
+++ b/src/test/kotlin/hu/netsurf/erp/usermanagement/util/UpdateUserPasswordInputValidatorTests.kt
@@ -4,6 +4,7 @@ import hu.netsurf.erp.testobject.UpdateUserPasswordInputTestObject
 import hu.netsurf.erp.usermanagement.exception.CurrentPasswordAndPasswordInDatabaseNotMatchesException
 import hu.netsurf.erp.usermanagement.exception.EmptyFieldException
 import hu.netsurf.erp.usermanagement.exception.NewPasswordAndConfirmNewPasswordNotMatchesException
+import hu.netsurf.erp.usermanagement.exception.NewPasswordAndPasswordInDatabaseMatchesException
 import hu.netsurf.erp.usermanagement.model.UpdateUserPasswordInput
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -50,6 +51,16 @@ class UpdateUserPasswordInputValidatorTests {
         assertThrows<CurrentPasswordAndPasswordInDatabaseNotMatchesException> {
             updateUserPasswordInputValidator.validate(
                 UpdateUserPasswordInputTestObject.updateUserPasswordInput1WithInvalidCurrentPassword(),
+                passwordInDatabase,
+            )
+        }
+    }
+
+    @Test
+    fun `validate test unhappy path - new password and password in database matches`() {
+        assertThrows<NewPasswordAndPasswordInDatabaseMatchesException> {
+            updateUserPasswordInputValidator.validate(
+                UpdateUserPasswordInputTestObject.updateUserPasswordInput1WithNewPasswordAndPasswordInDatabaseMatches(),
                 passwordInDatabase,
             )
         }

--- a/src/test/kotlin/hu/netsurf/erp/usermanagement/util/UpdateUserPasswordInputValidatorTests.kt
+++ b/src/test/kotlin/hu/netsurf/erp/usermanagement/util/UpdateUserPasswordInputValidatorTests.kt
@@ -1,7 +1,7 @@
 package hu.netsurf.erp.usermanagement.util
 
 import hu.netsurf.erp.testobject.UpdateUserPasswordInputTestObject
-import hu.netsurf.erp.usermanagement.exception.ConfirmCurrentPasswordException
+import hu.netsurf.erp.usermanagement.exception.CurrentPasswordAndPasswordInDatabaseNotMatchesException
 import hu.netsurf.erp.usermanagement.exception.EmptyFieldException
 import hu.netsurf.erp.usermanagement.exception.NewPasswordAndConfirmNewPasswordNotMatchesException
 import hu.netsurf.erp.usermanagement.model.UpdateUserPasswordInput
@@ -47,7 +47,7 @@ class UpdateUserPasswordInputValidatorTests {
 
     @Test
     fun `validate test unhappy path - current password and password in database not matches`() {
-        assertThrows<ConfirmCurrentPasswordException> {
+        assertThrows<CurrentPasswordAndPasswordInDatabaseNotMatchesException> {
             updateUserPasswordInputValidator.validate(
                 UpdateUserPasswordInputTestObject.updateUserPasswordInput1WithInvalidCurrentPassword(),
                 passwordInDatabase,

--- a/src/test/kotlin/hu/netsurf/erp/usermanagement/util/UpdateUserPasswordInputValidatorTests.kt
+++ b/src/test/kotlin/hu/netsurf/erp/usermanagement/util/UpdateUserPasswordInputValidatorTests.kt
@@ -2,8 +2,8 @@ package hu.netsurf.erp.usermanagement.util
 
 import hu.netsurf.erp.testobject.UpdateUserPasswordInputTestObject
 import hu.netsurf.erp.usermanagement.exception.ConfirmCurrentPasswordException
-import hu.netsurf.erp.usermanagement.exception.ConfirmNewPasswordException
 import hu.netsurf.erp.usermanagement.exception.EmptyFieldException
+import hu.netsurf.erp.usermanagement.exception.NewPasswordAndConfirmNewPasswordNotMatchesException
 import hu.netsurf.erp.usermanagement.model.UpdateUserPasswordInput
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -56,8 +56,8 @@ class UpdateUserPasswordInputValidatorTests {
     }
 
     @Test
-    fun `validate test unhappy path - password and confirm password not matches`() {
-        assertThrows<ConfirmNewPasswordException> {
+    fun `validate test unhappy path - new password and confirm new password not matches`() {
+        assertThrows<NewPasswordAndConfirmNewPasswordNotMatchesException> {
             updateUserPasswordInputValidator.validate(
                 UpdateUserPasswordInputTestObject.updateUserPasswordInput1WithInvalidConfirmNewPassword(),
                 passwordInDatabase,

--- a/src/test/kotlin/hu/netsurf/erp/usermanagement/util/UserInputValidatorTests.kt
+++ b/src/test/kotlin/hu/netsurf/erp/usermanagement/util/UserInputValidatorTests.kt
@@ -1,12 +1,12 @@
 package hu.netsurf.erp.usermanagement.util
 
 import hu.netsurf.erp.testobject.UserInputTestObject
-import hu.netsurf.erp.usermanagement.exception.ConfirmPasswordException
 import hu.netsurf.erp.usermanagement.exception.EmptyFieldException
 import hu.netsurf.erp.usermanagement.exception.InvalidEmailAddressFormatException
 import hu.netsurf.erp.usermanagement.exception.InvalidFirstNameFormatException
 import hu.netsurf.erp.usermanagement.exception.InvalidLastNameFormatException
 import hu.netsurf.erp.usermanagement.exception.InvalidLengthException
+import hu.netsurf.erp.usermanagement.exception.PasswordAndConfirmPasswordNotMatchesException
 import hu.netsurf.erp.usermanagement.model.UserInput
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -141,7 +141,7 @@ class UserInputValidatorTests {
 
     @Test
     fun `validate test unhappy path - password and confirm password not matches`() {
-        assertThrows<ConfirmPasswordException> {
+        assertThrows<PasswordAndConfirmPasswordNotMatchesException> {
             userInputValidator.validate(UserInputTestObject.userInput1WithInvalidConfirmPassword())
         }
     }


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [x] You have successfully built and run unit tests locally
- [x] There are new or updated unit tests validating the changes

### :pencil: Description

Implementing validation rule for checking newPassword not matches with the current password in datatabase. Renaming password related exception names.