### PR TITLE
Fix logger instantiation to use 'this' keyword instead of class name

### DIFF
--- a/src/main/kotlin/hu/netsurf/erp/usermanagement/controller/UserController.kt
+++ b/src/main/kotlin/hu/netsurf/erp/usermanagement/controller/UserController.kt
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController
 class UserController(
     private val userService: UserService,
 ) {
-    val logger: Logger = LoggerFactory.getLogger(UserController::class.java)
+    val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     @QueryMapping(name = "users")
     fun users(): List<User> {

--- a/src/main/kotlin/hu/netsurf/erp/usermanagement/service/UserService.kt
+++ b/src/main/kotlin/hu/netsurf/erp/usermanagement/service/UserService.kt
@@ -30,7 +30,7 @@ class UserService(
     private val updateUserPasswordInputSanitizer: UpdateUserPasswordInputSanitizer,
     private val updateUserPasswordInputValidator: UpdateUserPasswordInputValidator,
 ) {
-    val logger: Logger = LoggerFactory.getLogger(UserService::class.java)
+    val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     fun getUsers(): List<User> {
         logger.logInfo(USERS_RETRIEVED_FROM_DATABASE)

--- a/src/main/kotlin/hu/netsurf/erp/warehouse/controller/ProductController.kt
+++ b/src/main/kotlin/hu/netsurf/erp/warehouse/controller/ProductController.kt
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController
 class ProductController(
     private val productService: ProductService,
 ) {
-    val logger: Logger = LoggerFactory.getLogger(ProductController::class.java)
+    val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     @QueryMapping(name = "products")
     fun products(): List<Product> {

--- a/src/main/kotlin/hu/netsurf/erp/warehouse/controller/ProductPhotoController.kt
+++ b/src/main/kotlin/hu/netsurf/erp/warehouse/controller/ProductPhotoController.kt
@@ -39,7 +39,7 @@ import org.springframework.web.multipart.MultipartFile
 class ProductPhotoController(
     private val productPhotoService: ProductPhotoService,
 ) {
-    val logger: Logger = LoggerFactory.getLogger(ProductPhotoController::class.java)
+    val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     @GetMapping(path = ["/retrieve/{fileName}"])
     fun getProductPhoto(

--- a/src/main/kotlin/hu/netsurf/erp/warehouse/controller/SupplierController.kt
+++ b/src/main/kotlin/hu/netsurf/erp/warehouse/controller/SupplierController.kt
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController
 class SupplierController(
     private val supplierService: SupplierService,
 ) {
-    val logger: Logger = LoggerFactory.getLogger(ProductController::class.java)
+    val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     @QueryMapping(name = "suppliers")
     fun suppliers(): List<Supplier> {

--- a/src/main/kotlin/hu/netsurf/erp/warehouse/service/ProductPhotoService.kt
+++ b/src/main/kotlin/hu/netsurf/erp/warehouse/service/ProductPhotoService.kt
@@ -20,7 +20,7 @@ class ProductPhotoService(
     private val fileUtils: FileUtils,
     private val fileValidator: FileValidator,
 ) {
-    private val logger: Logger = LoggerFactory.getLogger(ProductPhotoService::class.java)
+    private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     fun getProductPhoto(fileName: String): ByteArray {
         val productPhoto: ByteArray

--- a/src/main/kotlin/hu/netsurf/erp/warehouse/service/ProductService.kt
+++ b/src/main/kotlin/hu/netsurf/erp/warehouse/service/ProductService.kt
@@ -22,7 +22,7 @@ class ProductService(
     private val productRepository: ProductRepository,
     private val supplierService: SupplierService,
 ) {
-    val logger: Logger = LoggerFactory.getLogger(ProductService::class.java)
+    val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     fun getProducts(): List<Product> {
         logger.logInfo(PRODUCTS_RETRIEVED_FROM_DATABASE)

--- a/src/main/kotlin/hu/netsurf/erp/warehouse/service/SupplierService.kt
+++ b/src/main/kotlin/hu/netsurf/erp/warehouse/service/SupplierService.kt
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Service
 class SupplierService(
     private val supplierRepository: SupplierRepository,
 ) {
-    val logger: Logger = LoggerFactory.getLogger(ProductService::class.java)
+    val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     fun getSuppliers(): List<Supplier> {
         logger.logInfo(SUPPLIERS_RETRIEVED_FROM_DATABASE)

--- a/src/main/kotlin/hu/netsurf/erp/warehouse/util/FileSystemUtils.kt
+++ b/src/main/kotlin/hu/netsurf/erp/warehouse/util/FileSystemUtils.kt
@@ -19,7 +19,7 @@ import java.util.UUID
 
 @Component
 class FileSystemUtils : FileUtils {
-    val logger: Logger = LoggerFactory.getLogger(FileSystemUtils::class.java)
+    val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     override fun readAllBytes(
         customSubdirectoryName: String,


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [ ] You have successfully built and run unit tests locally
- [ ] There are new or updated unit tests validating the changes

### :pencil: Description

Fixing logger instantiation to use 'this' keyword instead of class name.