### PR TITLE
Update Java version to 21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: "17"
+          java-version: "21"
           distribution: "temurin"
           cache: maven
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-alpine
+FROM eclipse-temurin:21-alpine
 
 WORKDIR /erp_api
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Prerequisites
 
 To avoid any unexpected application behaviour, make sure you have installed the following tools with the proper version numbers:
 
-- [Eclipse Temurin JDK](https://adoptium.net/temurin/releases)
+- [Eclipse Temurin JDK 21](https://adoptium.net/temurin/releases/?version=21)
 - [Maven 3.9.6](https://maven.apache.org/download.cgi)
 
 Running project locally

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <!-- Language versions -->
-        <java.version>17</java.version>
+        <java.version>21</java.version>
         <kotlin.version>2.0.20</kotlin.version>
 
         <!-- Project dependency versions -->


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [ ] You have successfully built and run unit tests locally
- [ ] There are new or updated unit tests validating the changes

### :pencil: Description

Updating Java version from 17 to 21 Long-Term Support version. Updating build GitHub Action and README.md with JDK 21 changes. Change Docker image from `openjdk` to `eclipse-temurin`.