### PR TITLE
Enhance readability of unit test by static import the test object instances

### DIFF
--- a/src/test/kotlin/hu/netsurf/erp/controller/ProductControllerTests.kt
+++ b/src/test/kotlin/hu/netsurf/erp/controller/ProductControllerTests.kt
@@ -1,8 +1,9 @@
 package hu.netsurf.erp.controller
 
 import hu.netsurf.erp.service.ProductService
-import hu.netsurf.erp.testobject.ProductInputTestObject
-import hu.netsurf.erp.testobject.ProductTestObject
+import hu.netsurf.erp.testobject.ProductInputTestObject.Companion.productInput1
+import hu.netsurf.erp.testobject.ProductTestObject.Companion.product1
+import hu.netsurf.erp.testobject.ProductTestObject.Companion.product2
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -17,7 +18,7 @@ class ProductControllerTests {
     fun `products test happy path`() {
         every {
             productService.getProducts()
-        } returns listOf(ProductTestObject.product1(), ProductTestObject.product2())
+        } returns listOf(product1(), product2())
 
         val result = productController.products()
         assertTrue(result.isNotEmpty())
@@ -27,9 +28,9 @@ class ProductControllerTests {
     fun `createProduct test happy path`() {
         every {
             productService.createProduct(any())
-        } returns ProductTestObject.product1()
+        } returns product1()
 
-        val result = productController.createProduct(ProductInputTestObject.productInput1())
-        assertEquals(ProductTestObject.product1(), result)
+        val result = productController.createProduct(productInput1())
+        assertEquals(product1(), result)
     }
 }

--- a/src/test/kotlin/hu/netsurf/erp/controller/SupplierControllerTests.kt
+++ b/src/test/kotlin/hu/netsurf/erp/controller/SupplierControllerTests.kt
@@ -1,8 +1,9 @@
 package hu.netsurf.erp.controller
 
 import hu.netsurf.erp.service.SupplierService
-import hu.netsurf.erp.testobject.SupplierInputTestObject
-import hu.netsurf.erp.testobject.SupplierTestObject
+import hu.netsurf.erp.testobject.SupplierInputTestObject.Companion.supplierInput1
+import hu.netsurf.erp.testobject.SupplierTestObject.Companion.supplier1
+import hu.netsurf.erp.testobject.SupplierTestObject.Companion.supplier2
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -17,7 +18,7 @@ class SupplierControllerTests {
     fun `suppliers test happy path`() {
         every {
             supplierService.getSuppliers()
-        } returns listOf(SupplierTestObject.supplier1(), SupplierTestObject.supplier2())
+        } returns listOf(supplier1(), supplier2())
 
         val result = supplierController.suppliers()
         assertTrue(result.isNotEmpty())
@@ -27,9 +28,9 @@ class SupplierControllerTests {
     fun `createSupplier test happy path`() {
         every {
             supplierService.createSupplier(any())
-        } returns SupplierTestObject.supplier1()
+        } returns supplier1()
 
-        val result = supplierController.createSupplier(SupplierInputTestObject.supplierInput1())
-        assertEquals(SupplierTestObject.supplier1(), result)
+        val result = supplierController.createSupplier(supplierInput1())
+        assertEquals(supplier1(), result)
     }
 }

--- a/src/test/kotlin/hu/netsurf/erp/controller/UserControllerTests.kt
+++ b/src/test/kotlin/hu/netsurf/erp/controller/UserControllerTests.kt
@@ -1,9 +1,10 @@
 package hu.netsurf.erp.controller
 
 import hu.netsurf.erp.service.UserService
-import hu.netsurf.erp.testobject.UpdateUserPasswordInputTestObject
-import hu.netsurf.erp.testobject.UserInputTestObject
-import hu.netsurf.erp.testobject.UserTestObject
+import hu.netsurf.erp.testobject.UpdateUserPasswordInputTestObject.Companion.updateUserPasswordInput1
+import hu.netsurf.erp.testobject.UserInputTestObject.Companion.userInput1
+import hu.netsurf.erp.testobject.UserTestObject.Companion.user1
+import hu.netsurf.erp.testobject.UserTestObject.Companion.user2
 import hu.netsurf.erp.util.UpdateUserPasswordInputSanitizer
 import hu.netsurf.erp.util.UpdateUserPasswordInputValidator
 import hu.netsurf.erp.util.UserInputSanitizer
@@ -34,7 +35,7 @@ class UserControllerTests {
     fun `users test happy path`() {
         every {
             userService.getUsers()
-        } returns listOf(UserTestObject.user1(), UserTestObject.user2())
+        } returns listOf(user1(), user2())
 
         val result = userController.users()
         assertTrue(result.isNotEmpty())
@@ -44,30 +45,30 @@ class UserControllerTests {
     fun `createUser test happy path`() {
         every {
             userInputSanitizer.sanitize(any())
-        } returns UserInputTestObject.userInput1()
+        } returns userInput1()
         justRun { userInputValidator.validate(any()) }
         every {
             userService.createUser(any())
-        } returns UserTestObject.user1()
+        } returns user1()
 
-        val result = userController.createUser(UserInputTestObject.userInput1())
-        assertEquals(UserTestObject.user1(), result)
+        val result = userController.createUser(userInput1())
+        assertEquals(user1(), result)
     }
 
     @Test
     fun `updateUserPassword test happy path`() {
         every {
             updateUserPasswordInputSanitizer.sanitize(any())
-        } returns UpdateUserPasswordInputTestObject.updateUserPasswordInput1()
+        } returns updateUserPasswordInput1()
         every {
             userService.getUser(any())
-        } returns UserTestObject.user1()
+        } returns user1()
         justRun { updateUserPasswordInputValidator.validate(any(), any()) }
         every {
             userService.updateUser(any())
-        } returns UserTestObject.user1()
+        } returns user1()
 
-        val result = userController.updateUserPassword(UpdateUserPasswordInputTestObject.updateUserPasswordInput1())
-        assertEquals(UserTestObject.user1(), result)
+        val result = userController.updateUserPassword(updateUserPasswordInput1())
+        assertEquals(user1(), result)
     }
 }

--- a/src/test/kotlin/hu/netsurf/erp/service/ProductPhotoServiceTests.kt
+++ b/src/test/kotlin/hu/netsurf/erp/service/ProductPhotoServiceTests.kt
@@ -7,7 +7,8 @@ import hu.netsurf.erp.TestConstants.PHOTO_FILE_NAME
 import hu.netsurf.erp.TestConstants.UPLOADS_DIRECTORY_WITH_PHOTOS_SUBDIRECTORY_AND_CUSTOM_SUBDIRECTORY
 import hu.netsurf.erp.exception.ProductAlreadyHasPhotoUploadedException
 import hu.netsurf.erp.exception.ProductPhotoNotFoundException
-import hu.netsurf.erp.testobject.ProductTestObject
+import hu.netsurf.erp.testobject.ProductTestObject.Companion.product1
+import hu.netsurf.erp.testobject.ProductTestObject.Companion.product1WithPhoto
 import hu.netsurf.erp.util.FileUtils
 import hu.netsurf.erp.util.FileValidator
 import io.mockk.every
@@ -60,12 +61,12 @@ class ProductPhotoServiceTests {
 
     @Test
     fun `uploadProductPhoto test happy path`() {
-        every { productService.getProduct(1) } returns ProductTestObject.product1()
+        every { productService.getProduct(1) } returns product1()
         every {
             fileUtils.createPhotoUploadsDirectoryStructure(any())
         } returns UPLOADS_DIRECTORY_WITH_PHOTOS_SUBDIRECTORY_AND_CUSTOM_SUBDIRECTORY
         every { fileUtils.storePhoto(any(), any()) } returns PHOTO_FILE_NAME
-        every { productService.updateProduct(any()) } returns ProductTestObject.product1WithPhoto()
+        every { productService.updateProduct(any()) } returns product1WithPhoto()
 
         val result = productPhotoService.uploadProductPhoto(1, multipartFile)
         assertFalse(result.isNullOrBlank())
@@ -73,7 +74,7 @@ class ProductPhotoServiceTests {
 
     @Test
     fun `uploadProductPhoto test unhappy path`() {
-        every { productService.getProduct(1) } returns ProductTestObject.product1WithPhoto()
+        every { productService.getProduct(1) } returns product1WithPhoto()
 
         assertThrows<ProductAlreadyHasPhotoUploadedException> {
             productPhotoService.uploadProductPhoto(1, multipartFile)

--- a/src/test/kotlin/hu/netsurf/erp/service/ProductServiceTests.kt
+++ b/src/test/kotlin/hu/netsurf/erp/service/ProductServiceTests.kt
@@ -2,8 +2,9 @@ package hu.netsurf.erp.service
 
 import hu.netsurf.erp.exception.ProductNotFoundException
 import hu.netsurf.erp.repository.ProductRepository
-import hu.netsurf.erp.testobject.ProductTestObject
-import hu.netsurf.erp.testobject.SupplierTestObject
+import hu.netsurf.erp.testobject.ProductTestObject.Companion.product1
+import hu.netsurf.erp.testobject.ProductTestObject.Companion.product2
+import hu.netsurf.erp.testobject.SupplierTestObject.Companion.supplier1
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
@@ -23,7 +24,7 @@ class ProductServiceTests {
     fun `getProducts test happy path`() {
         every {
             productRepository.findAll()
-        } returns listOf(ProductTestObject.product1(), ProductTestObject.product2())
+        } returns listOf(product1(), product2())
 
         val result = productService.getProducts()
         assertTrue(result.isNotEmpty())
@@ -33,7 +34,7 @@ class ProductServiceTests {
     fun `getProduct test happy path`() {
         every {
             productRepository.findById(any())
-        } returns Optional.of(ProductTestObject.product1())
+        } returns Optional.of(product1())
 
         assertDoesNotThrow {
             val result = productService.getProduct(1)
@@ -57,22 +58,22 @@ class ProductServiceTests {
     fun `createProduct test happy path`() {
         every {
             productRepository.save(any())
-        } returns ProductTestObject.product1()
+        } returns product1()
         every {
             supplierService.getSupplier(any())
-        } returns SupplierTestObject.supplier1()
+        } returns supplier1()
 
-        val result = productService.createProduct(ProductTestObject.product1())
-        assertEquals(ProductTestObject.product1(), result)
+        val result = productService.createProduct(product1())
+        assertEquals(product1(), result)
     }
 
     @Test
     fun `updateProduct test happy path`() {
         every {
             productRepository.save(any())
-        } returns ProductTestObject.product1()
+        } returns product1()
 
-        val result = productService.updateProduct(ProductTestObject.product1())
-        assertEquals(ProductTestObject.product1(), result)
+        val result = productService.updateProduct(product1())
+        assertEquals(product1(), result)
     }
 }

--- a/src/test/kotlin/hu/netsurf/erp/service/SupplierServiceTests.kt
+++ b/src/test/kotlin/hu/netsurf/erp/service/SupplierServiceTests.kt
@@ -2,7 +2,8 @@ package hu.netsurf.erp.service
 
 import hu.netsurf.erp.exception.SupplierNotFoundException
 import hu.netsurf.erp.repository.SupplierRepository
-import hu.netsurf.erp.testobject.SupplierTestObject
+import hu.netsurf.erp.testobject.SupplierTestObject.Companion.supplier1
+import hu.netsurf.erp.testobject.SupplierTestObject.Companion.supplier2
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
@@ -21,7 +22,7 @@ class SupplierServiceTests {
     fun `getSuppliers test happy path`() {
         every {
             supplierRepository.findAll()
-        } returns listOf(SupplierTestObject.supplier1(), SupplierTestObject.supplier2())
+        } returns listOf(supplier1(), supplier2())
 
         val result = supplierService.getSuppliers()
         assertTrue(result.isNotEmpty())
@@ -31,7 +32,7 @@ class SupplierServiceTests {
     fun `getSupplier test happy path`() {
         every {
             supplierRepository.findById(any())
-        } returns Optional.of(SupplierTestObject.supplier1())
+        } returns Optional.of(supplier1())
 
         assertDoesNotThrow {
             val result = supplierService.getSupplier(1)
@@ -55,12 +56,12 @@ class SupplierServiceTests {
     fun `createSupplier test happy path`() {
         every {
             supplierRepository.save(any())
-        } returns SupplierTestObject.supplier1()
+        } returns supplier1()
         every {
             supplierRepository.findById(any())
-        } returns Optional.of(SupplierTestObject.supplier1())
+        } returns Optional.of(supplier1())
 
-        val result = supplierService.createSupplier(SupplierTestObject.supplier1())
-        assertEquals(SupplierTestObject.supplier1(), result)
+        val result = supplierService.createSupplier(supplier1())
+        assertEquals(supplier1(), result)
     }
 }

--- a/src/test/kotlin/hu/netsurf/erp/service/UserServiceTests.kt
+++ b/src/test/kotlin/hu/netsurf/erp/service/UserServiceTests.kt
@@ -2,7 +2,8 @@ package hu.netsurf.erp.service
 
 import hu.netsurf.erp.exception.UserNotFoundException
 import hu.netsurf.erp.repository.UserRepository
-import hu.netsurf.erp.testobject.UserTestObject
+import hu.netsurf.erp.testobject.UserTestObject.Companion.user1
+import hu.netsurf.erp.testobject.UserTestObject.Companion.user2
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
@@ -21,7 +22,7 @@ class UserServiceTests {
     fun `getUsers test happy path`() {
         every {
             userRepository.findAll()
-        } returns listOf(UserTestObject.user1(), UserTestObject.user2())
+        } returns listOf(user1(), user2())
 
         val result = userService.getUsers()
         assertTrue(result.isNotEmpty())
@@ -31,7 +32,7 @@ class UserServiceTests {
     fun `getUser test happy path`() {
         every {
             userRepository.findById(1)
-        } returns Optional.of(UserTestObject.user1())
+        } returns Optional.of(user1())
 
         assertDoesNotThrow {
             val result = userService.getUser(1)
@@ -55,19 +56,19 @@ class UserServiceTests {
     fun `createUser test happy path`() {
         every {
             userRepository.save(any())
-        } returns UserTestObject.user1()
+        } returns user1()
 
-        val result = userService.createUser(UserTestObject.user1())
-        assertEquals(UserTestObject.user1(), result)
+        val result = userService.createUser(user1())
+        assertEquals(user1(), result)
     }
 
     @Test
     fun `updateUser test happy path`() {
         every {
             userRepository.save(any())
-        } returns UserTestObject.user1()
+        } returns user1()
 
-        val result = userService.updateUser(UserTestObject.user1())
-        assertEquals(UserTestObject.user1(), result)
+        val result = userService.updateUser(user1())
+        assertEquals(user1(), result)
     }
 }

--- a/src/test/kotlin/hu/netsurf/erp/util/UpdateUserPasswordInputValidatorTests.kt
+++ b/src/test/kotlin/hu/netsurf/erp/util/UpdateUserPasswordInputValidatorTests.kt
@@ -6,7 +6,13 @@ import hu.netsurf.erp.exception.EmptyFieldException
 import hu.netsurf.erp.exception.NewPasswordAndConfirmNewPasswordNotMatchesException
 import hu.netsurf.erp.exception.NewPasswordAndPasswordInDatabaseMatchesException
 import hu.netsurf.erp.input.UpdateUserPasswordInput
-import hu.netsurf.erp.testobject.UpdateUserPasswordInputTestObject
+import hu.netsurf.erp.testobject.UpdateUserPasswordInputTestObject.Companion.updateUserPasswordInput1
+import hu.netsurf.erp.testobject.UpdateUserPasswordInputTestObject.Companion.updateUserPasswordInput1WithInvalidConfirmNewPassword
+import hu.netsurf.erp.testobject.UpdateUserPasswordInputTestObject.Companion.updateUserPasswordInput1WithInvalidCurrentPassword
+import hu.netsurf.erp.testobject.UpdateUserPasswordInputTestObject.Companion.updateUserPasswordInput1WithNewPasswordAndPasswordInDatabaseMatches
+import hu.netsurf.erp.testobject.UpdateUserPasswordInputTestObject.Companion.userInput1WithEmptyConfirmNewPassword
+import hu.netsurf.erp.testobject.UpdateUserPasswordInputTestObject.Companion.userInput1WithEmptyCurrentPassword
+import hu.netsurf.erp.testobject.UpdateUserPasswordInputTestObject.Companion.userInput1WithEmptyNewPassword
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -23,16 +29,16 @@ class UpdateUserPasswordInputValidatorTests {
         @JvmStatic
         fun updateUserPasswordInputEmptyFieldParams(): Stream<Arguments> =
             Stream.of(
-                Arguments.of("current password is empty", UpdateUserPasswordInputTestObject.userInput1WithEmptyCurrentPassword()),
-                Arguments.of("new password is empty", UpdateUserPasswordInputTestObject.userInput1WithEmptyNewPassword()),
-                Arguments.of("confirm new password is empty", UpdateUserPasswordInputTestObject.userInput1WithEmptyConfirmNewPassword()),
+                Arguments.of("current password is empty", userInput1WithEmptyCurrentPassword()),
+                Arguments.of("new password is empty", userInput1WithEmptyNewPassword()),
+                Arguments.of("confirm new password is empty", userInput1WithEmptyConfirmNewPassword()),
             )
     }
 
     @Test
     fun `validate test happy path`() {
         assertDoesNotThrow {
-            updateUserPasswordInputValidator.validate(UpdateUserPasswordInputTestObject.updateUserPasswordInput1(), passwordInDatabase)
+            updateUserPasswordInputValidator.validate(updateUserPasswordInput1(), passwordInDatabase)
         }
     }
 
@@ -51,7 +57,7 @@ class UpdateUserPasswordInputValidatorTests {
     fun `validate test unhappy path - current password and password in database not matches`() {
         assertThrows<CurrentPasswordAndPasswordInDatabaseNotMatchesException> {
             updateUserPasswordInputValidator.validate(
-                UpdateUserPasswordInputTestObject.updateUserPasswordInput1WithInvalidCurrentPassword(),
+                updateUserPasswordInput1WithInvalidCurrentPassword(),
                 passwordInDatabase,
             )
         }
@@ -61,7 +67,7 @@ class UpdateUserPasswordInputValidatorTests {
     fun `validate test unhappy path - new password and password in database matches`() {
         assertThrows<NewPasswordAndPasswordInDatabaseMatchesException> {
             updateUserPasswordInputValidator.validate(
-                UpdateUserPasswordInputTestObject.updateUserPasswordInput1WithNewPasswordAndPasswordInDatabaseMatches(),
+                updateUserPasswordInput1WithNewPasswordAndPasswordInDatabaseMatches(),
                 passwordInDatabase,
             )
         }
@@ -71,7 +77,7 @@ class UpdateUserPasswordInputValidatorTests {
     fun `validate test unhappy path - new password and confirm new password not matches`() {
         assertThrows<NewPasswordAndConfirmNewPasswordNotMatchesException> {
             updateUserPasswordInputValidator.validate(
-                UpdateUserPasswordInputTestObject.updateUserPasswordInput1WithInvalidConfirmNewPassword(),
+                updateUserPasswordInput1WithInvalidConfirmNewPassword(),
                 passwordInDatabase,
             )
         }

--- a/src/test/kotlin/hu/netsurf/erp/util/UserInputValidatorTests.kt
+++ b/src/test/kotlin/hu/netsurf/erp/util/UserInputValidatorTests.kt
@@ -17,7 +17,25 @@ import hu.netsurf.erp.exception.InvalidLastNameFormatException
 import hu.netsurf.erp.exception.InvalidLengthException
 import hu.netsurf.erp.exception.PasswordAndConfirmPasswordNotMatchesException
 import hu.netsurf.erp.input.UserInput
-import hu.netsurf.erp.testobject.UserInputTestObject
+import hu.netsurf.erp.testobject.UserInputTestObject.Companion.userInput1
+import hu.netsurf.erp.testobject.UserInputTestObject.Companion.userInput1WithEmptyConfirmPassword
+import hu.netsurf.erp.testobject.UserInputTestObject.Companion.userInput1WithEmptyEmail
+import hu.netsurf.erp.testobject.UserInputTestObject.Companion.userInput1WithEmptyFirstName
+import hu.netsurf.erp.testobject.UserInputTestObject.Companion.userInput1WithEmptyLastName
+import hu.netsurf.erp.testobject.UserInputTestObject.Companion.userInput1WithEmptyPassword
+import hu.netsurf.erp.testobject.UserInputTestObject.Companion.userInput1WithEmptyUsername
+import hu.netsurf.erp.testobject.UserInputTestObject.Companion.userInput1WithInvalidConfirmPassword
+import hu.netsurf.erp.testobject.UserInputTestObject.Companion.userInput1WithInvalidEmail
+import hu.netsurf.erp.testobject.UserInputTestObject.Companion.userInput1WithLongEmail
+import hu.netsurf.erp.testobject.UserInputTestObject.Companion.userInput1WithLongFirstName
+import hu.netsurf.erp.testobject.UserInputTestObject.Companion.userInput1WithLongLastName
+import hu.netsurf.erp.testobject.UserInputTestObject.Companion.userInput1WithLongPassword
+import hu.netsurf.erp.testobject.UserInputTestObject.Companion.userInput1WithLongUsername
+import hu.netsurf.erp.testobject.UserInputTestObject.Companion.userInput1WithShortEmail
+import hu.netsurf.erp.testobject.UserInputTestObject.Companion.userInput1WithShortFirstName
+import hu.netsurf.erp.testobject.UserInputTestObject.Companion.userInput1WithShortLastName
+import hu.netsurf.erp.testobject.UserInputTestObject.Companion.userInput1WithShortPassword
+import hu.netsurf.erp.testobject.UserInputTestObject.Companion.userInput1WithShortUsername
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -33,27 +51,27 @@ class UserInputValidatorTests {
         @JvmStatic
         fun userInputEmptyFieldParams(): Stream<Arguments> =
             Stream.of(
-                Arguments.of("username is empty", UserInputTestObject.userInput1WithEmptyUsername()),
-                Arguments.of("password is empty", UserInputTestObject.userInput1WithEmptyPassword()),
-                Arguments.of("confirmPassword is empty", UserInputTestObject.userInput1WithEmptyConfirmPassword()),
-                Arguments.of("firstName is empty", UserInputTestObject.userInput1WithEmptyFirstName()),
-                Arguments.of("lastName is empty", UserInputTestObject.userInput1WithEmptyLastName()),
-                Arguments.of("email is empty", UserInputTestObject.userInput1WithEmptyEmail()),
+                Arguments.of("username is empty", userInput1WithEmptyUsername()),
+                Arguments.of("password is empty", userInput1WithEmptyPassword()),
+                Arguments.of("confirmPassword is empty", userInput1WithEmptyConfirmPassword()),
+                Arguments.of("firstName is empty", userInput1WithEmptyFirstName()),
+                Arguments.of("lastName is empty", userInput1WithEmptyLastName()),
+                Arguments.of("email is empty", userInput1WithEmptyEmail()),
             )
 
         @JvmStatic
         fun userInputFieldLengthParams(): Stream<Arguments> =
             Stream.of(
-                Arguments.of("username is too short", UserInputTestObject.userInput1WithShortUsername()),
-                Arguments.of("username is too long", UserInputTestObject.userInput1WithLongUsername()),
-                Arguments.of("password is too short", UserInputTestObject.userInput1WithShortPassword()),
-                Arguments.of("password is too long", UserInputTestObject.userInput1WithLongPassword()),
-                Arguments.of("firstName is too short", UserInputTestObject.userInput1WithShortFirstName()),
-                Arguments.of("firstName is too long", UserInputTestObject.userInput1WithLongFirstName()),
-                Arguments.of("lastName is too short", UserInputTestObject.userInput1WithShortLastName()),
-                Arguments.of("lastName is too long", UserInputTestObject.userInput1WithLongLastName()),
-                Arguments.of("email is too short", UserInputTestObject.userInput1WithShortEmail()),
-                Arguments.of("email is too long", UserInputTestObject.userInput1WithLongEmail()),
+                Arguments.of("username is too short", userInput1WithShortUsername()),
+                Arguments.of("username is too long", userInput1WithLongUsername()),
+                Arguments.of("password is too short", userInput1WithShortPassword()),
+                Arguments.of("password is too long", userInput1WithLongPassword()),
+                Arguments.of("firstName is too short", userInput1WithShortFirstName()),
+                Arguments.of("firstName is too long", userInput1WithLongFirstName()),
+                Arguments.of("lastName is too short", userInput1WithShortLastName()),
+                Arguments.of("lastName is too long", userInput1WithLongLastName()),
+                Arguments.of("email is too short", userInput1WithShortEmail()),
+                Arguments.of("email is too long", userInput1WithLongEmail()),
             )
 
         @JvmStatic
@@ -74,7 +92,7 @@ class UserInputValidatorTests {
     @Test
     fun `validate test happy path`() {
         assertDoesNotThrow {
-            userInputValidator.validate(UserInputTestObject.userInput1())
+            userInputValidator.validate(userInput1())
         }
     }
 
@@ -145,14 +163,14 @@ class UserInputValidatorTests {
     @Test
     fun `validate test unhappy path - invalid email address`() {
         assertThrows<InvalidEmailAddressFormatException> {
-            userInputValidator.validate(UserInputTestObject.userInput1WithInvalidEmail())
+            userInputValidator.validate(userInput1WithInvalidEmail())
         }
     }
 
     @Test
     fun `validate test unhappy path - password and confirm password not matches`() {
         assertThrows<PasswordAndConfirmPasswordNotMatchesException> {
-            userInputValidator.validate(UserInputTestObject.userInput1WithInvalidConfirmPassword())
+            userInputValidator.validate(userInput1WithInvalidConfirmPassword())
         }
     }
 }


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [x] You have successfully built and run unit tests locally
- [x] There are new or updated unit tests validating the changes

### :pencil: Description

Using Companion when import the test object instances to make unit test readable.