### PR TITLE
Decouple low level components from MultipartFile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@
                         <exclude>hu/netsurf/erp/constant/**</exclude>
                         <exclude>hu/netsurf/erp/model/**</exclude>
                         <exclude>hu/netsurf/erp/util/FileSystemUtils*</exclude>
+                        <exclude>hu/netsurf/erp/wrapper/**</exclude>
                         <exclude>hu/netsurf/erp/Application*</exclude>
                     </excludes>
                 </configuration>

--- a/src/main/kotlin/hu/netsurf/erp/constant/LogEventConstants.kt
+++ b/src/main/kotlin/hu/netsurf/erp/constant/LogEventConstants.kt
@@ -36,6 +36,10 @@ enum class LogEventConstants(
         eventName = "erp-api:productPhotoController:uploadProductPhoto:RequestReceived",
         eventMessage = "Product photo upload request received",
     ),
+    MULTIPART_FILE_MAPPED_TO_PHOTO_FILE(
+        eventName = "erp-api:productPhotoController:uploadProductPhoto:MultipartFileMappedToPhotoFile",
+        eventMessage = "MultipartFile mapped to ProductPhotoFile",
+    ),
     UPLOAD_PRODUCT_PHOTO_SUCCESS_RESPONSE(
         eventName = "erp-api:productPhotoController:uploadProductPhoto:SuccessResponse",
         eventMessage = "Product photo upload was successful",
@@ -84,9 +88,9 @@ enum class LogEventConstants(
         eventName = "erp-api:userController:updateUserPassword:SuccessResponse",
         eventMessage = "Update user password GraphQL mutation success response",
     ),
-    MULTIPART_FILE_VALIDATED_SUCCESSFULLY(
+    PHOTO_FILE_VALIDATED_SUCCESSFULLY(
         eventName = "erp-api:productPhotoService:uploadPhoto",
-        eventMessage = "Multipart file validated successfully",
+        eventMessage = "PhotoFile validated successfully",
     ),
     PRODUCTS_RETRIEVED_FROM_DATABASE(
         eventName = "erp-api:productService:getProducts",

--- a/src/main/kotlin/hu/netsurf/erp/constant/LoggerConstants.kt
+++ b/src/main/kotlin/hu/netsurf/erp/constant/LoggerConstants.kt
@@ -12,6 +12,7 @@ object LoggerConstants {
     const val SUPPLIER = "Supplier"
     const val SUPPLIER_INPUT = "SupplierInput"
     const val MULTIPART_FILE = "MultipartFile"
+    const val PHOTO_FILE = "PhotoFile"
     const val UPLOADS_DIRECTORY_PATH = "UploadsDirectoryPath"
     const val USER = "User"
     const val USER_INPUT = "UserInput"

--- a/src/main/kotlin/hu/netsurf/erp/controller/ProductPhotoController.kt
+++ b/src/main/kotlin/hu/netsurf/erp/controller/ProductPhotoController.kt
@@ -4,12 +4,14 @@ import hu.netsurf.erp.constant.FileConstants.IMAGE
 import hu.netsurf.erp.constant.LogEventConstants.GET_PRODUCT_PHOTO_FAILURE_RESPONSE
 import hu.netsurf.erp.constant.LogEventConstants.GET_PRODUCT_PHOTO_REQUEST_RECEIVED
 import hu.netsurf.erp.constant.LogEventConstants.GET_PRODUCT_PHOTO_SUCCESS_RESPONSE
+import hu.netsurf.erp.constant.LogEventConstants.MULTIPART_FILE_MAPPED_TO_PHOTO_FILE
 import hu.netsurf.erp.constant.LogEventConstants.UPLOAD_PRODUCT_PHOTO_FAILURE_RESPONSE
 import hu.netsurf.erp.constant.LogEventConstants.UPLOAD_PRODUCT_PHOTO_REQUEST_RECEIVED
 import hu.netsurf.erp.constant.LogEventConstants.UPLOAD_PRODUCT_PHOTO_SUCCESS_RESPONSE
 import hu.netsurf.erp.constant.LoggerConstants.CONTENT_TYPE
 import hu.netsurf.erp.constant.LoggerConstants.FILE_NAME
 import hu.netsurf.erp.constant.LoggerConstants.MULTIPART_FILE
+import hu.netsurf.erp.constant.LoggerConstants.PHOTO_FILE
 import hu.netsurf.erp.constant.LoggerConstants.PRODUCT_ID
 import hu.netsurf.erp.constant.LoggerConstants.PRODUCT_PHOTO_FILE_NAME
 import hu.netsurf.erp.exception.NotFoundException
@@ -17,7 +19,9 @@ import hu.netsurf.erp.extension.asString
 import hu.netsurf.erp.extension.getExtension
 import hu.netsurf.erp.extension.logError
 import hu.netsurf.erp.extension.logInfo
+import hu.netsurf.erp.extension.toPhotoFile
 import hu.netsurf.erp.service.ProductPhotoService
+import hu.netsurf.erp.wrapper.PhotoFile
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpHeaders
@@ -88,7 +92,17 @@ class ProductPhotoController(
                 ),
             )
 
-            val productPhotoFileName = productPhotoService.uploadProductPhoto(productId, file)
+            val photoFile: PhotoFile = file.toPhotoFile()
+
+            logger.logInfo(
+                MULTIPART_FILE_MAPPED_TO_PHOTO_FILE,
+                mapOf(
+                    MULTIPART_FILE to file.asString(),
+                    PHOTO_FILE to photoFile.asString(),
+                ),
+            )
+
+            val productPhotoFileName = productPhotoService.uploadProductPhoto(productId, photoFile)
 
             logger.logInfo(
                 UPLOAD_PRODUCT_PHOTO_SUCCESS_RESPONSE,

--- a/src/main/kotlin/hu/netsurf/erp/extension/MultipartFileExtensions.kt
+++ b/src/main/kotlin/hu/netsurf/erp/extension/MultipartFileExtensions.kt
@@ -1,9 +1,15 @@
 package hu.netsurf.erp.extension
 
+import hu.netsurf.erp.wrapper.PhotoFile
 import org.springframework.web.multipart.MultipartFile
 
-fun MultipartFile.getExtension(): String = this.originalFilename!!.getExtension()
-
-fun String.getExtension(): String = this.split('.')[1].lowercase()
-
 fun MultipartFile.asString(): String = "{originalFileName=${this.originalFilename} size=${this.size} contentType=${this.contentType}}"
+
+fun MultipartFile.toPhotoFile(): PhotoFile =
+    PhotoFile(
+        isEmpty = this.isEmpty,
+        originalFilename = this.originalFilename,
+        size = this.size,
+        contentType = this.contentType,
+        inputStreamBytes = this.inputStream.readBytes(),
+    )

--- a/src/main/kotlin/hu/netsurf/erp/extension/StringExtensions.kt
+++ b/src/main/kotlin/hu/netsurf/erp/extension/StringExtensions.kt
@@ -1,0 +1,3 @@
+package hu.netsurf.erp.extension
+
+fun String.getExtension(): String = this.split('.')[1].lowercase()

--- a/src/main/kotlin/hu/netsurf/erp/service/ProductPhotoService.kt
+++ b/src/main/kotlin/hu/netsurf/erp/service/ProductPhotoService.kt
@@ -1,18 +1,17 @@
 package hu.netsurf.erp.service
 
 import hu.netsurf.erp.constant.FileConstants.PRODUCTS_SUBDIRECTORY_NAME
-import hu.netsurf.erp.constant.LogEventConstants.MULTIPART_FILE_VALIDATED_SUCCESSFULLY
-import hu.netsurf.erp.constant.LoggerConstants.MULTIPART_FILE
+import hu.netsurf.erp.constant.LogEventConstants.PHOTO_FILE_VALIDATED_SUCCESSFULLY
+import hu.netsurf.erp.constant.LoggerConstants.PHOTO_FILE
 import hu.netsurf.erp.exception.ProductAlreadyHasPhotoUploadedException
 import hu.netsurf.erp.exception.ProductPhotoNotFoundException
-import hu.netsurf.erp.extension.asString
 import hu.netsurf.erp.extension.logInfo
 import hu.netsurf.erp.util.FileUtils
 import hu.netsurf.erp.util.FileValidator
+import hu.netsurf.erp.wrapper.PhotoFile
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import org.springframework.web.multipart.MultipartFile
 
 @Service
 class ProductPhotoService(
@@ -36,13 +35,13 @@ class ProductPhotoService(
 
     fun uploadProductPhoto(
         productId: Int,
-        file: MultipartFile,
+        file: PhotoFile,
     ): String? {
         fileValidator.validate(file)
 
         logger.logInfo(
-            MULTIPART_FILE_VALIDATED_SUCCESSFULLY,
-            mapOf(MULTIPART_FILE to file.asString()),
+            PHOTO_FILE_VALIDATED_SUCCESSFULLY,
+            mapOf(PHOTO_FILE to file.asString()),
         )
 
         val product = productService.getProduct(productId)

--- a/src/main/kotlin/hu/netsurf/erp/util/FileSystemUtils.kt
+++ b/src/main/kotlin/hu/netsurf/erp/util/FileSystemUtils.kt
@@ -7,12 +7,11 @@ import hu.netsurf.erp.constant.LogEventConstants.PHOTO_STORED_ON_FILE_SYSTEM
 import hu.netsurf.erp.constant.LogEventConstants.PHOTO_UPLOADS_DIRECTORY_CREATED_ON_FILE_SYSTEM
 import hu.netsurf.erp.constant.LoggerConstants.FILE_NAME
 import hu.netsurf.erp.constant.LoggerConstants.UPLOADS_DIRECTORY_PATH
-import hu.netsurf.erp.extension.getExtension
 import hu.netsurf.erp.extension.logInfo
+import hu.netsurf.erp.wrapper.PhotoFile
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
-import org.springframework.web.multipart.MultipartFile
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.UUID
@@ -67,13 +66,13 @@ class FileSystemUtils : FileUtils {
     }
 
     override fun storePhoto(
-        file: MultipartFile,
+        file: PhotoFile,
         directoryStructurePath: String,
     ): String {
         val fileName = "${UUID.randomUUID()}.${file.getExtension()}"
         val pathWithFileName = Paths.get(directoryStructurePath, fileName)
 
-        Files.copy(file.inputStream, pathWithFileName)
+        Files.copy(file.inputStream(), pathWithFileName)
 
         logger.logInfo(
             PHOTO_STORED_ON_FILE_SYSTEM,

--- a/src/main/kotlin/hu/netsurf/erp/util/FileUtils.kt
+++ b/src/main/kotlin/hu/netsurf/erp/util/FileUtils.kt
@@ -1,6 +1,6 @@
 package hu.netsurf.erp.util
 
-import org.springframework.web.multipart.MultipartFile
+import hu.netsurf.erp.wrapper.PhotoFile
 
 interface FileUtils {
     fun readAllBytes(
@@ -11,7 +11,7 @@ interface FileUtils {
     fun createPhotoUploadsDirectoryStructure(customSubdirectoryName: String): String
 
     fun storePhoto(
-        file: MultipartFile,
+        file: PhotoFile,
         directoryStructurePath: String,
     ): String
 }

--- a/src/main/kotlin/hu/netsurf/erp/util/FileValidator.kt
+++ b/src/main/kotlin/hu/netsurf/erp/util/FileValidator.kt
@@ -3,15 +3,14 @@
 import hu.netsurf.erp.config.FileExtensionsConfig
 import hu.netsurf.erp.exception.EmptyFileException
 import hu.netsurf.erp.exception.InvalidFileExtensionException
-import hu.netsurf.erp.extension.getExtension
+import hu.netsurf.erp.wrapper.PhotoFile
 import org.springframework.stereotype.Component
-import org.springframework.web.multipart.MultipartFile
 
 @Component
 class FileValidator(
     val fileExtensionsConfig: FileExtensionsConfig,
 ) {
-    fun validate(file: MultipartFile) {
+    fun validate(file: PhotoFile) {
         if (file.isEmpty) {
             throw EmptyFileException(fileName = file.originalFilename)
         }

--- a/src/main/kotlin/hu/netsurf/erp/wrapper/PhotoFile.kt
+++ b/src/main/kotlin/hu/netsurf/erp/wrapper/PhotoFile.kt
@@ -8,11 +8,11 @@ class PhotoFile(
     val originalFilename: String?,
     val size: Long,
     val contentType: String?,
-    val inputStream: InputStream,
+    val inputStreamBytes: ByteArray,
 ) {
-    fun asString(): String {
-        return "{originalFileName=${this.originalFilename} size=${this.size} contentType=${this.contentType}}"
-    }
+    fun asString(): String = "{originalFileName=${this.originalFilename} size=${this.size} contentType=${this.contentType}}"
 
     fun getExtension(): String = this.originalFilename!!.getExtension()
+
+    fun inputStream(): InputStream = this.inputStreamBytes.inputStream()
 }

--- a/src/main/kotlin/hu/netsurf/erp/wrapper/PhotoFile.kt
+++ b/src/main/kotlin/hu/netsurf/erp/wrapper/PhotoFile.kt
@@ -1,0 +1,18 @@
+package hu.netsurf.erp.wrapper
+
+import hu.netsurf.erp.extension.getExtension
+import java.io.InputStream
+
+class PhotoFile(
+    val isEmpty: Boolean,
+    val originalFilename: String?,
+    val size: Long,
+    val contentType: String?,
+    val inputStream: InputStream,
+) {
+    fun asString(): String {
+        return "{originalFileName=${this.originalFilename} size=${this.size} contentType=${this.contentType}}"
+    }
+
+    fun getExtension(): String = this.originalFilename!!.getExtension()
+}

--- a/src/test/kotlin/hu/netsurf/erp/TestConstants.kt
+++ b/src/test/kotlin/hu/netsurf/erp/TestConstants.kt
@@ -2,13 +2,14 @@ package hu.netsurf.erp
 
 object TestConstants {
     const val EMPTY_STRING = ""
-    const val MULTIPART_FILE_SIZE = 10485760
+    const val FILE_SIZE = 10485760
     const val CONTENT_TYPE_IMAGE_JPEG = "image/jpeg"
     const val ORIGINAL_FILE_NAME = "file_name.jpeg"
     const val ORIGINAL_FILE_EXTENSION = "jpeg"
     const val INVALID_ORIGINAL_FILE_NAME = "file_name.txt"
     const val INVALID_ORIGINAL_FILE_EXTENSION = "txt"
     const val PHOTO_FILE_NAME = "7a759fbb-39d8-4b3b-af57-4266980901dc.jpeg"
+    const val PHOTO_FILE_AS_STRING = "{originalFileName=${ORIGINAL_FILE_NAME} size=${FILE_SIZE} contentType=${CONTENT_TYPE_IMAGE_JPEG}}"
     const val UPLOADS_DIRECTORY_WITH_PHOTOS_SUBDIRECTORY_AND_CUSTOM_SUBDIRECTORY = "uploads/photos/products/"
     val ALLOWED_EXTENSIONS = listOf("jpg", "jpeg", "png", "bmp")
     const val PRODUCT_1_NAME = "Product#1"

--- a/src/test/kotlin/hu/netsurf/erp/TestConstants.kt
+++ b/src/test/kotlin/hu/netsurf/erp/TestConstants.kt
@@ -3,16 +3,20 @@ package hu.netsurf.erp
 object TestConstants {
     const val EMPTY_STRING = ""
     const val FILE_SIZE = 10485760
+    private const val JPG = "jpg"
+    private const val JPEG = "jpeg"
+    private const val PNG = "png"
+    private const val BMP = "bmp"
     const val CONTENT_TYPE_IMAGE_JPEG = "image/jpeg"
     const val FILE_NAME = "file_name.jpeg"
     const val ORIGINAL_FILE_NAME = FILE_NAME
-    const val ORIGINAL_FILE_EXTENSION = "jpeg"
+    const val ORIGINAL_FILE_EXTENSION = JPEG
     const val INVALID_ORIGINAL_FILE_NAME = "file_name.txt"
     const val INVALID_ORIGINAL_FILE_EXTENSION = "txt"
     const val PHOTO_FILE_NAME = "7a759fbb-39d8-4b3b-af57-4266980901dc.jpeg"
     const val PHOTO_FILE_AS_STRING = "{originalFileName=${ORIGINAL_FILE_NAME} size=${FILE_SIZE} contentType=${CONTENT_TYPE_IMAGE_JPEG}}"
     const val UPLOADS_DIRECTORY_WITH_PHOTOS_SUBDIRECTORY_AND_CUSTOM_SUBDIRECTORY = "uploads/photos/products/"
-    val ALLOWED_EXTENSIONS = listOf("jpg", "jpeg", "png", "bmp")
+    val ALLOWED_EXTENSIONS = listOf(JPG, JPEG, PNG, BMP)
     const val PRODUCT_1_NAME = "Product#1"
     const val PRODUCT_1_UNIT = "pieces"
     const val PRODUCT_2_NAME = "Product#2"

--- a/src/test/kotlin/hu/netsurf/erp/TestConstants.kt
+++ b/src/test/kotlin/hu/netsurf/erp/TestConstants.kt
@@ -5,7 +5,9 @@ object TestConstants {
     const val MULTIPART_FILE_SIZE = 10485760
     const val CONTENT_TYPE_IMAGE_JPEG = "image/jpeg"
     const val ORIGINAL_FILE_NAME = "file_name.jpeg"
+    const val ORIGINAL_FILE_EXTENSION = "jpeg"
     const val INVALID_ORIGINAL_FILE_NAME = "file_name.txt"
+    const val INVALID_ORIGINAL_FILE_EXTENSION = "txt"
     const val PHOTO_FILE_NAME = "7a759fbb-39d8-4b3b-af57-4266980901dc.jpeg"
     const val UPLOADS_DIRECTORY_WITH_PHOTOS_SUBDIRECTORY_AND_CUSTOM_SUBDIRECTORY = "uploads/photos/products/"
     val ALLOWED_EXTENSIONS = listOf("jpg", "jpeg", "png", "bmp")

--- a/src/test/kotlin/hu/netsurf/erp/TestConstants.kt
+++ b/src/test/kotlin/hu/netsurf/erp/TestConstants.kt
@@ -4,7 +4,8 @@ object TestConstants {
     const val EMPTY_STRING = ""
     const val FILE_SIZE = 10485760
     const val CONTENT_TYPE_IMAGE_JPEG = "image/jpeg"
-    const val ORIGINAL_FILE_NAME = "file_name.jpeg"
+    const val FILE_NAME = "file_name.jpeg"
+    const val ORIGINAL_FILE_NAME = FILE_NAME
     const val ORIGINAL_FILE_EXTENSION = "jpeg"
     const val INVALID_ORIGINAL_FILE_NAME = "file_name.txt"
     const val INVALID_ORIGINAL_FILE_EXTENSION = "txt"

--- a/src/test/kotlin/hu/netsurf/erp/controller/ProductPhotoControllerTests.kt
+++ b/src/test/kotlin/hu/netsurf/erp/controller/ProductPhotoControllerTests.kt
@@ -1,7 +1,8 @@
 package hu.netsurf.erp.controller
 
 import hu.netsurf.erp.TestConstants.CONTENT_TYPE_IMAGE_JPEG
-import hu.netsurf.erp.TestConstants.MULTIPART_FILE_SIZE
+import hu.netsurf.erp.TestConstants.FILE_NAME
+import hu.netsurf.erp.TestConstants.FILE_SIZE
 import hu.netsurf.erp.TestConstants.ORIGINAL_FILE_NAME
 import hu.netsurf.erp.TestConstants.PHOTO_FILE_NAME
 import hu.netsurf.erp.exception.ProductAlreadyHasPhotoUploadedException
@@ -12,40 +13,39 @@ import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
+import org.springframework.mock.web.MockMultipartFile
 import org.springframework.web.multipart.MultipartFile
 import java.io.IOException
 
 class ProductPhotoControllerTests {
     private val productPhotoService: ProductPhotoService = mockk()
     private val productPhotoController: ProductPhotoController = ProductPhotoController(productPhotoService)
-    private val multipartFile: MultipartFile = mockk<MultipartFile>()
-
-    @BeforeEach
-    fun setup() {
-        every { multipartFile.originalFilename } returns ORIGINAL_FILE_NAME
-        every { multipartFile.size } returns MULTIPART_FILE_SIZE.toLong()
-        every { multipartFile.contentType } returns CONTENT_TYPE_IMAGE_JPEG
-    }
+    private val multipartFile: MultipartFile =
+        MockMultipartFile(
+            FILE_NAME,
+            ORIGINAL_FILE_NAME,
+            CONTENT_TYPE_IMAGE_JPEG,
+            ByteArray(1024),
+        )
 
     @Test
     fun `getProductPhoto test happy path`() {
         every {
-            productPhotoService.getProductPhoto(PHOTO_FILE_NAME)
-        } returns ByteArray(MULTIPART_FILE_SIZE)
+            productPhotoService.getProductPhoto(any())
+        } returns ByteArray(FILE_SIZE)
 
         val result = productPhotoController.getProductPhoto(PHOTO_FILE_NAME)
         assertEquals(HttpStatus.OK, result.statusCode)
         assertEquals(CONTENT_TYPE_IMAGE_JPEG, result.headers.contentType.toString())
-        assertTrue(result.body.toString().isNotEmpty())
+        assertTrue(result.body is ByteArray)
     }
 
     @Test
     fun `getProductPhoto test unhappy path - product photo not found (HTTP 404)`() {
         every {
-            productPhotoService.getProductPhoto(PHOTO_FILE_NAME)
+            productPhotoService.getProductPhoto(any())
         } throws ProductPhotoNotFoundException(PHOTO_FILE_NAME)
 
         val result = productPhotoController.getProductPhoto(PHOTO_FILE_NAME)
@@ -60,47 +60,47 @@ class ProductPhotoControllerTests {
     fun `getProductPhoto test unhappy path - bad request (HTTP 400)`() {
         val exceptionMessage = "IOException occurred."
         every {
-            productPhotoService.getProductPhoto(PHOTO_FILE_NAME)
+            productPhotoService.getProductPhoto(any())
         } throws IOException(exceptionMessage)
 
         val result = productPhotoController.getProductPhoto(PHOTO_FILE_NAME)
         assertEquals(HttpStatus.BAD_REQUEST, result.statusCode)
-        assertEquals(exceptionMessage, result.body.toString())
+        assertEquals(exceptionMessage, result.body)
     }
 
     @Test
     fun `createProductPhoto test happy path`() {
         every {
-            productPhotoService.uploadProductPhoto(1, multipartFile)
+            productPhotoService.uploadProductPhoto(any(), any())
         } returns PHOTO_FILE_NAME
 
         val result = productPhotoController.createProductPhoto(1, multipartFile)
         assertEquals(HttpStatus.OK, result.statusCode)
-        assertEquals(PHOTO_FILE_NAME, result.body.toString())
+        assertEquals(PHOTO_FILE_NAME, result.body)
     }
 
     @Test
     fun `createProductPhoto test unhappy path - product not found (HTTP 404)`() {
         every {
-            productPhotoService.uploadProductPhoto(3, multipartFile)
+            productPhotoService.uploadProductPhoto(any(), any())
         } throws ProductNotFoundException(3)
 
         val result = productPhotoController.createProductPhoto(3, multipartFile)
         assertEquals(HttpStatus.NOT_FOUND, result.statusCode)
-        assertEquals("Termék a következő azonosítóval: #3 nem található.", result.body.toString())
+        assertEquals("Termék a következő azonosítóval: #3 nem található.", result.body)
     }
 
     @Test
     fun `createProductPhoto test unhappy path - product already has photo uploaded (HTTP 400)`() {
         every {
-            productPhotoService.uploadProductPhoto(1, multipartFile)
+            productPhotoService.uploadProductPhoto(any(), any())
         } throws ProductAlreadyHasPhotoUploadedException(1)
 
         val result = productPhotoController.createProductPhoto(1, multipartFile)
         assertEquals(HttpStatus.BAD_REQUEST, result.statusCode)
         assertEquals(
             "Termék a következő azonosítóval: #1 már rendelkezik feltöltött fényképpel.",
-            result.body.toString(),
+            result.body,
         )
     }
 }

--- a/src/test/kotlin/hu/netsurf/erp/service/ProductPhotoServiceTests.kt
+++ b/src/test/kotlin/hu/netsurf/erp/service/ProductPhotoServiceTests.kt
@@ -1,8 +1,7 @@
 package hu.netsurf.erp.service
 
-import hu.netsurf.erp.TestConstants.CONTENT_TYPE_IMAGE_JPEG
-import hu.netsurf.erp.TestConstants.MULTIPART_FILE_SIZE
-import hu.netsurf.erp.TestConstants.ORIGINAL_FILE_NAME
+import hu.netsurf.erp.TestConstants.FILE_SIZE
+import hu.netsurf.erp.TestConstants.PHOTO_FILE_AS_STRING
 import hu.netsurf.erp.TestConstants.PHOTO_FILE_NAME
 import hu.netsurf.erp.TestConstants.UPLOADS_DIRECTORY_WITH_PHOTOS_SUBDIRECTORY_AND_CUSTOM_SUBDIRECTORY
 import hu.netsurf.erp.exception.ProductAlreadyHasPhotoUploadedException
@@ -11,6 +10,7 @@ import hu.netsurf.erp.testobject.ProductTestObject.Companion.product1
 import hu.netsurf.erp.testobject.ProductTestObject.Companion.product1WithPhoto
 import hu.netsurf.erp.util.FileUtils
 import hu.netsurf.erp.util.FileValidator
+import hu.netsurf.erp.wrapper.PhotoFile
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.springframework.web.multipart.MultipartFile
 import java.io.IOException
 
 class ProductPhotoServiceTests {
@@ -27,22 +26,20 @@ class ProductPhotoServiceTests {
     private val fileUtils: FileUtils = mockk()
     private val fileValidator: FileValidator = mockk()
     private val productPhotoService: ProductPhotoService = ProductPhotoService(productService, fileUtils, fileValidator)
-    private val multipartFile: MultipartFile = mockk<MultipartFile>()
+    private val photoFile: PhotoFile = mockk()
 
     @BeforeEach
     fun setup() {
         justRun { fileValidator.validate(any()) }
 
-        every { multipartFile.originalFilename } returns ORIGINAL_FILE_NAME
-        every { multipartFile.size } returns MULTIPART_FILE_SIZE.toLong()
-        every { multipartFile.contentType } returns CONTENT_TYPE_IMAGE_JPEG
+        every { photoFile.asString() } returns PHOTO_FILE_AS_STRING
     }
 
     @Test
     fun `getProductPhoto test happy path`() {
         every {
             fileUtils.readAllBytes(any(), any())
-        } returns ByteArray(MULTIPART_FILE_SIZE)
+        } returns ByteArray(FILE_SIZE)
 
         val result = productPhotoService.getProductPhoto(PHOTO_FILE_NAME)
         assertTrue(result.isNotEmpty())
@@ -68,7 +65,7 @@ class ProductPhotoServiceTests {
         every { fileUtils.storePhoto(any(), any()) } returns PHOTO_FILE_NAME
         every { productService.updateProduct(any()) } returns product1WithPhoto()
 
-        val result = productPhotoService.uploadProductPhoto(1, multipartFile)
+        val result = productPhotoService.uploadProductPhoto(1, photoFile)
         assertFalse(result.isNullOrBlank())
     }
 
@@ -77,7 +74,7 @@ class ProductPhotoServiceTests {
         every { productService.getProduct(1) } returns product1WithPhoto()
 
         assertThrows<ProductAlreadyHasPhotoUploadedException> {
-            productPhotoService.uploadProductPhoto(1, multipartFile)
+            productPhotoService.uploadProductPhoto(1, photoFile)
         }
     }
 }

--- a/src/test/kotlin/hu/netsurf/erp/util/FileValidatorTests.kt
+++ b/src/test/kotlin/hu/netsurf/erp/util/FileValidatorTests.kt
@@ -1,28 +1,31 @@
 package hu.netsurf.erp.util
 
 import hu.netsurf.erp.TestConstants.ALLOWED_EXTENSIONS
+import hu.netsurf.erp.TestConstants.INVALID_ORIGINAL_FILE_EXTENSION
 import hu.netsurf.erp.TestConstants.INVALID_ORIGINAL_FILE_NAME
+import hu.netsurf.erp.TestConstants.ORIGINAL_FILE_EXTENSION
 import hu.netsurf.erp.TestConstants.ORIGINAL_FILE_NAME
 import hu.netsurf.erp.config.FileExtensionsConfig
 import hu.netsurf.erp.exception.EmptyFileException
 import hu.netsurf.erp.exception.InvalidFileExtensionException
+import hu.netsurf.erp.wrapper.PhotoFile
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.springframework.web.multipart.MultipartFile
 
 class FileValidatorTests {
     private val fileExtensionsConfig: FileExtensionsConfig = mockk()
     private val fileValidator: FileValidator = FileValidator(fileExtensionsConfig)
-    private val multipartFile: MultipartFile = mockk<MultipartFile>()
+    private val photoFile: PhotoFile = mockk()
 
     @BeforeEach
     fun setup() {
-        every { multipartFile.isEmpty } returns false
-        every { multipartFile.originalFilename } returns ORIGINAL_FILE_NAME
+        every { photoFile.isEmpty } returns false
+        every { photoFile.originalFilename } returns ORIGINAL_FILE_NAME
+        every { photoFile.getExtension() } returns ORIGINAL_FILE_EXTENSION
 
         every { fileExtensionsConfig.allowedExtensions } returns ALLOWED_EXTENSIONS
     }
@@ -30,25 +33,26 @@ class FileValidatorTests {
     @Test
     fun `validate test happy path`() {
         assertDoesNotThrow {
-            fileValidator.validate(multipartFile)
+            fileValidator.validate(photoFile)
         }
     }
 
     @Test
     fun `validate test unhappy path - file is empty`() {
-        every { multipartFile.isEmpty } returns true
+        every { photoFile.isEmpty } returns true
 
         assertThrows<EmptyFileException> {
-            fileValidator.validate(multipartFile)
+            fileValidator.validate(photoFile)
         }
     }
 
     @Test
     fun `validate test unhappy path - file has not allowed extension`() {
-        every { multipartFile.originalFilename } returns INVALID_ORIGINAL_FILE_NAME
+        every { photoFile.originalFilename } returns INVALID_ORIGINAL_FILE_NAME
+        every { photoFile.getExtension() } returns INVALID_ORIGINAL_FILE_EXTENSION
 
         assertThrows<InvalidFileExtensionException> {
-            fileValidator.validate(multipartFile)
+            fileValidator.validate(photoFile)
         }
     }
 }


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [x] You have successfully built and run unit tests locally
- [x] There are new or updated unit tests validating the changes

### :pencil: Description

Decoupling low level components from Spring Boot Web's `MultipartFile` object and mapping it to a custom object to keep those services reusable apart from Spring Boot.