### PR TITLE
Fix fields to nullable in SupplierInput

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,10 +31,10 @@
         <ktlint.version>3.5.0</ktlint.version>
 
         <!-- JaCoCo properties -->
-        <jacoco.line-coverage>0.99</jacoco.line-coverage>
+        <jacoco.line-coverage>1.00</jacoco.line-coverage>
         <jacoco.branch-coverage>1.00</jacoco.branch-coverage>
-        <jacoco.complexity-coverage>0.99</jacoco.complexity-coverage>
-        <jacoco.method-coverage>0.99</jacoco.method-coverage>
+        <jacoco.complexity-coverage>1.00</jacoco.complexity-coverage>
+        <jacoco.method-coverage>1.00</jacoco.method-coverage>
         <jacoco.class-coverage>1.00</jacoco.class-coverage>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,10 +31,10 @@
         <ktlint.version>3.4.0</ktlint.version>
 
         <!-- JaCoCo properties -->
-        <jacoco.line-coverage>1.00</jacoco.line-coverage>
+        <jacoco.line-coverage>0.99</jacoco.line-coverage>
         <jacoco.branch-coverage>1.00</jacoco.branch-coverage>
-        <jacoco.complexity-coverage>1.00</jacoco.complexity-coverage>
-        <jacoco.method-coverage>1.00</jacoco.method-coverage>
+        <jacoco.complexity-coverage>0.99</jacoco.complexity-coverage>
+        <jacoco.method-coverage>0.99</jacoco.method-coverage>
         <jacoco.class-coverage>1.00</jacoco.class-coverage>
     </properties>
 

--- a/src/main/kotlin/hu/netsurf/erp/constant/SupplierValidationConstants.kt
+++ b/src/main/kotlin/hu/netsurf/erp/constant/SupplierValidationConstants.kt
@@ -3,8 +3,8 @@ package hu.netsurf.erp.constant
 object SupplierValidationConstants {
     const val NAME_MIN_LENGTH = 1
     const val NAME_MAX_LENGTH = 255
-    const val EMAIL_MIN_LENGTH = 1
-    const val EMAIL_MAX_LENGTH = 75
     const val PHONE_MIN_LENGTH = 1
     const val PHONE_MAX_LENGTH = 25
+    const val EMAIL_MIN_LENGTH = 1
+    const val EMAIL_MAX_LENGTH = 75
 }

--- a/src/main/kotlin/hu/netsurf/erp/input/SupplierInput.kt
+++ b/src/main/kotlin/hu/netsurf/erp/input/SupplierInput.kt
@@ -10,8 +10,8 @@ import hu.netsurf.erp.constant.SupplierValidationConstants.PHONE_MIN_LENGTH
 
 data class SupplierInput(
     val name: String,
-    val phone: String? = null,
-    val email: String? = null,
+    val phone: String?,
+    val email: String?,
 ) {
     fun nameIsEmpty(): Boolean = name.isEmpty()
 

--- a/src/main/kotlin/hu/netsurf/erp/input/SupplierInput.kt
+++ b/src/main/kotlin/hu/netsurf/erp/input/SupplierInput.kt
@@ -10,8 +10,8 @@ import hu.netsurf.erp.constant.SupplierValidationConstants.PHONE_MIN_LENGTH
 
 data class SupplierInput(
     val name: String,
-    val email: String,
-    val phone: String,
+    val phone: String? = null,
+    val email: String? = null,
 ) {
     fun nameIsEmpty(): Boolean = name.isEmpty()
 
@@ -19,13 +19,13 @@ data class SupplierInput(
 
     fun nameIsLong(): Boolean = name.length > NAME_MAX_LENGTH
 
-    fun emailIsShort(): Boolean = email.length <= EMAIL_MIN_LENGTH
+    fun phoneIsShort(): Boolean = phone!!.length <= PHONE_MIN_LENGTH
 
-    fun emailIsLong(): Boolean = email.length > EMAIL_MAX_LENGTH
+    fun phoneIsLong(): Boolean = phone!!.length > PHONE_MAX_LENGTH
 
-    fun phoneIsShort(): Boolean = phone.length <= PHONE_MIN_LENGTH
+    fun emailAddressIsValid(): Boolean = email!!.matches(Regex(EMAIL_ADDRESS_REGEX))
 
-    fun phoneIsLong(): Boolean = phone.length > PHONE_MAX_LENGTH
+    fun emailIsShort(): Boolean = email!!.length <= EMAIL_MIN_LENGTH
 
-    fun emailAddressIsValid(): Boolean = email.matches(Regex(EMAIL_ADDRESS_REGEX))
+    fun emailIsLong(): Boolean = email!!.length > EMAIL_MAX_LENGTH
 }

--- a/src/main/kotlin/hu/netsurf/erp/util/SupplierInputSanitizer.kt
+++ b/src/main/kotlin/hu/netsurf/erp/util/SupplierInputSanitizer.kt
@@ -10,7 +10,7 @@ class SupplierInputSanitizer(
     fun sanitize(userInput: SupplierInput): SupplierInput =
         SupplierInput(
             name = inputSanitizer.sanitize(userInput.name),
-            email = inputSanitizer.sanitize(userInput.email),
-            phone = inputSanitizer.sanitize(userInput.phone),
+            email = inputSanitizer.sanitize(userInput.email!!),
+            phone = inputSanitizer.sanitize(userInput.phone!!),
         )
 }

--- a/src/test/kotlin/hu/netsurf/erp/controller/SupplierControllerTests.kt
+++ b/src/test/kotlin/hu/netsurf/erp/controller/SupplierControllerTests.kt
@@ -2,7 +2,11 @@ package hu.netsurf.erp.controller
 
 import hu.netsurf.erp.service.SupplierService
 import hu.netsurf.erp.testobject.SupplierInputTestObject.Companion.supplierInput1
+import hu.netsurf.erp.testobject.SupplierInputTestObject.Companion.supplierInput1WithNullEmail
+import hu.netsurf.erp.testobject.SupplierInputTestObject.Companion.supplierInput1WithNullPhone
 import hu.netsurf.erp.testobject.SupplierTestObject.Companion.supplier1
+import hu.netsurf.erp.testobject.SupplierTestObject.Companion.supplier1WithNullEmail
+import hu.netsurf.erp.testobject.SupplierTestObject.Companion.supplier1WithNullPhone
 import hu.netsurf.erp.testobject.SupplierTestObject.Companion.supplier2
 import io.mockk.every
 import io.mockk.mockk
@@ -32,5 +36,25 @@ class SupplierControllerTests {
 
         val result = supplierController.createSupplier(supplierInput1())
         assertEquals(supplier1(), result)
+    }
+
+    @Test
+    fun `createSupplier test happy path - phone is null`() {
+        every {
+            supplierService.createSupplier(any())
+        } returns supplier1WithNullPhone()
+
+        val result = supplierController.createSupplier(supplierInput1WithNullPhone())
+        assertEquals(supplier1WithNullPhone(), result)
+    }
+
+    @Test
+    fun `createSupplier test happy path - email is null`() {
+        every {
+            supplierService.createSupplier(any())
+        } returns supplier1WithNullEmail()
+
+        val result = supplierController.createSupplier(supplierInput1WithNullEmail())
+        assertEquals(supplier1WithNullEmail(), result)
     }
 }

--- a/src/test/kotlin/hu/netsurf/erp/testobject/SupplierInputTestObject.kt
+++ b/src/test/kotlin/hu/netsurf/erp/testobject/SupplierInputTestObject.kt
@@ -24,16 +24,20 @@ class SupplierInputTestObject {
 
         fun supplierInput1WithLongPhone(): SupplierInput = build(phone = SUPPLIER_LONG_PHONE)
 
+        fun supplierInput1WithNullPhone(): SupplierInput = build(phone = null)
+
         fun supplierInput1WithShortEmail(): SupplierInput = build(email = "a")
 
         fun supplierInput1WithLongEmail(): SupplierInput = build(email = SUPPLIER_LONG_EMAIL)
 
         fun supplierInput1WithInvalidEmail(): SupplierInput = build(email = SUPPLIER_INVALID_EMAIL)
 
+        fun supplierInput1WithNullEmail(): SupplierInput = build(email = null)
+
         private fun build(
             name: String = SUPPLIER_1_NAME,
-            phone: String = SUPPLIER_1_PHONE,
-            email: String = SUPPLIER_1_EMAIL,
+            phone: String? = SUPPLIER_1_PHONE,
+            email: String? = SUPPLIER_1_EMAIL,
         ): SupplierInput =
             SupplierInput(
                 name = name,

--- a/src/test/kotlin/hu/netsurf/erp/testobject/SupplierTestObject.kt
+++ b/src/test/kotlin/hu/netsurf/erp/testobject/SupplierTestObject.kt
@@ -12,6 +12,10 @@ class SupplierTestObject {
     companion object {
         fun supplier1(): Supplier = build()
 
+        fun supplier1WithNullPhone(): Supplier = build(phone = null)
+
+        fun supplier1WithNullEmail(): Supplier = build(email = null)
+
         fun supplier2(): Supplier =
             build(
                 id = 2,
@@ -23,8 +27,8 @@ class SupplierTestObject {
         private fun build(
             id: Int = 1,
             name: String = SUPPLIER_1_NAME,
-            phone: String = SUPPLIER_1_PHONE,
-            email: String = SUPPLIER_1_EMAIL,
+            phone: String? = SUPPLIER_1_PHONE,
+            email: String? = SUPPLIER_1_EMAIL,
         ): Supplier =
             Supplier(
                 id = id,


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [x] You have successfully built and run unit tests locally
- [ ] There are new or updated unit tests validating the changes

### :pencil: Description

Set 'phone' and 'email' fields to nullable in SupplierInput. When not filling these fields it will be empty initially, but these fields can be null, as well in database as a NULL value.