### PR TITLE
Temporarily set  'mysql' Docker image to `8.4` LTS version.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   database:
-    image: mysql
+    image: mysql:8.4
     container_name: erp_database
     restart: always
     environment:


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [x] You have successfully built and run unit tests locally
- [ ] There are new or updated unit tests validating the changes

### :pencil: Description

Temporarily setting 'mysql' Docker image to `8.4` LTS version, because from here Docker allows major version update (`9.x`)