### PR TITLE
Remove version tag from 'mysql' Docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   database:
-    image: mysql:9.2
+    image: mysql
     container_name: erp_database
     restart: always
     environment:


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [x] You have successfully built and run unit tests locally
- [ ] There are new or updated unit tests validating the changes

### :pencil: Description

Previoulsy in #125 had to update 'mysql' Docker image to LTS version, then it can be directly updated to version `9.x`. Now removing version tag from 'mysql' Docker image to use `latest` by default again.