### PR TITLE
Implement constraints for password

### DIFF
--- a/src/main/kotlin/hu/netsurf/erp/usermanagement/constant/RegexPatterns.kt
+++ b/src/main/kotlin/hu/netsurf/erp/usermanagement/constant/RegexPatterns.kt
@@ -1,0 +1,5 @@
+package hu.netsurf.erp.usermanagement.constant
+
+object RegexPatterns {
+    const val PASSWORD_REGEX = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z0-9]).{8,15}$"
+}

--- a/src/main/kotlin/hu/netsurf/erp/usermanagement/constant/UserValidationConstants.kt
+++ b/src/main/kotlin/hu/netsurf/erp/usermanagement/constant/UserValidationConstants.kt
@@ -3,8 +3,6 @@ package hu.netsurf.erp.usermanagement.constant
 object UserValidationConstants {
     const val USERNAME_MIN_LENGTH = 5
     const val USERNAME_MAX_LENGTH = 15
-    const val PASSWORD_MIN_LENGTH = 5
-    const val PASSWORD_MAX_LENGTH = 15
     const val FIRST_NAME_MIN_LENGTH = 1
     const val FIRST_NAME_MAX_LENGTH = 255
     const val LAST_NAME_MIN_LENGTH = 1

--- a/src/main/kotlin/hu/netsurf/erp/usermanagement/exception/InvalidPasswordFormatException.kt
+++ b/src/main/kotlin/hu/netsurf/erp/usermanagement/exception/InvalidPasswordFormatException.kt
@@ -1,0 +1,3 @@
+package hu.netsurf.erp.usermanagement.exception
+
+class InvalidPasswordFormatException : Exception("Nem megfelelő jelszó formátum.")

--- a/src/main/kotlin/hu/netsurf/erp/usermanagement/input/UserInput.kt
+++ b/src/main/kotlin/hu/netsurf/erp/usermanagement/input/UserInput.kt
@@ -1,14 +1,13 @@
 package hu.netsurf.erp.usermanagement.input
 
 import hu.netsurf.erp.common.constant.RegexPatterns.EMAIL_ADDRESS_REGEX
+import hu.netsurf.erp.usermanagement.constant.RegexPatterns.PASSWORD_REGEX
 import hu.netsurf.erp.usermanagement.constant.UserValidationConstants.EMAIL_MAX_LENGTH
 import hu.netsurf.erp.usermanagement.constant.UserValidationConstants.EMAIL_MIN_LENGTH
 import hu.netsurf.erp.usermanagement.constant.UserValidationConstants.FIRST_NAME_MAX_LENGTH
 import hu.netsurf.erp.usermanagement.constant.UserValidationConstants.FIRST_NAME_MIN_LENGTH
 import hu.netsurf.erp.usermanagement.constant.UserValidationConstants.LAST_NAME_MAX_LENGTH
 import hu.netsurf.erp.usermanagement.constant.UserValidationConstants.LAST_NAME_MIN_LENGTH
-import hu.netsurf.erp.usermanagement.constant.UserValidationConstants.PASSWORD_MAX_LENGTH
-import hu.netsurf.erp.usermanagement.constant.UserValidationConstants.PASSWORD_MIN_LENGTH
 import hu.netsurf.erp.usermanagement.constant.UserValidationConstants.USERNAME_MAX_LENGTH
 import hu.netsurf.erp.usermanagement.constant.UserValidationConstants.USERNAME_MIN_LENGTH
 import hu.netsurf.erp.usermanagement.model.User
@@ -28,10 +27,6 @@ data class UserInput(
     fun usernameIsLong(): Boolean = username.length > USERNAME_MAX_LENGTH
 
     fun passwordIsEmpty(): Boolean = password.isEmpty()
-
-    fun passwordIsShort(): Boolean = password.length < PASSWORD_MIN_LENGTH
-
-    fun passwordIsLong(): Boolean = password.length > PASSWORD_MAX_LENGTH
 
     fun confirmPasswordIsEmpty(): Boolean = confirmPassword.isEmpty()
 
@@ -64,6 +59,8 @@ data class UserInput(
     fun emailAddressIsValid(): Boolean = email.matches(Regex(EMAIL_ADDRESS_REGEX))
 
     fun passwordAndConfirmPasswordMatches(): Boolean = password == confirmPassword
+
+    fun passwordIsValid(): Boolean = password.matches(Regex(PASSWORD_REGEX))
 
     fun toUser(): User =
         User(

--- a/src/main/kotlin/hu/netsurf/erp/usermanagement/util/UserInputValidator.kt
+++ b/src/main/kotlin/hu/netsurf/erp/usermanagement/util/UserInputValidator.kt
@@ -5,6 +5,7 @@ import hu.netsurf.erp.common.exception.InvalidLengthException
 import hu.netsurf.erp.usermanagement.exception.InvalidEmailAddressFormatException
 import hu.netsurf.erp.usermanagement.exception.InvalidFirstNameFormatException
 import hu.netsurf.erp.usermanagement.exception.InvalidLastNameFormatException
+import hu.netsurf.erp.usermanagement.exception.InvalidPasswordFormatException
 import hu.netsurf.erp.usermanagement.exception.PasswordAndConfirmPasswordNotMatchesException
 import hu.netsurf.erp.usermanagement.input.UserInput
 import org.springframework.stereotype.Component
@@ -26,8 +27,6 @@ class UserInputValidator {
         if (
             userInput.usernameIsShort() ||
             userInput.usernameIsLong() ||
-            userInput.passwordIsShort() ||
-            userInput.passwordIsLong() ||
             userInput.firstNameIsShort() ||
             userInput.firstNameIsLong() ||
             userInput.lastNameIsShort() ||
@@ -60,6 +59,10 @@ class UserInputValidator {
 
         if (!userInput.passwordAndConfirmPasswordMatches()) {
             throw PasswordAndConfirmPasswordNotMatchesException()
+        }
+
+        if (!userInput.passwordIsValid()) {
+            throw InvalidPasswordFormatException()
         }
     }
 }

--- a/src/test/kotlin/hu/netsurf/erp/usermanagement/constant/UserTestConstants.kt
+++ b/src/test/kotlin/hu/netsurf/erp/usermanagement/constant/UserTestConstants.kt
@@ -1,13 +1,12 @@
 package hu.netsurf.erp.usermanagement.constant
 
 object UserTestConstants {
-    const val PASSWORD = "pAsSwOrD"
-    const val HASHED_PASSWORD = "\$2a\$10\$7vTcNn6sN49ke5oMK6TrxO7kVPXYqLd2gD8o0JcHFVEoZ6Qdk1u7W\n"
-    const val INVALID_PASSWORD = "pAsSwOrD1"
-    const val LONG_PASSWORD = "pAsSwOrDpAsSwOrD"
-    const val INVALID_CONFIRM_PASSWORD = "CoNfIrMpAsSwOrD"
+    const val PASSWORD = "p@sSw0rD"
     const val NEW_PASSWORD = "NeWpAsSwOrD"
+    const val INVALID_CURRENT_PASSWORD = "pAsSwOrD1"
+    const val INVALID_CONFIRM_PASSWORD = "CoNfIrMpAsSwOrD"
     const val INVALID_NEW_PASSWORD = "NeWpAsSwOrD1"
+    const val HASHED_PASSWORD = "\$2a\$10\$7vTcNn6sN49ke5oMK6TrxO7kVPXYqLd2gD8o0JcHFVEoZ6Qdk1u7W\n"
     const val USERNAME_1 = "jbence"
     const val USERNAME_2 = "jgabor"
     const val LONG_USERNAME_1 =

--- a/src/test/kotlin/hu/netsurf/erp/usermanagement/testobject/UpdateUserPasswordInputTestObject.kt
+++ b/src/test/kotlin/hu/netsurf/erp/usermanagement/testobject/UpdateUserPasswordInputTestObject.kt
@@ -1,8 +1,8 @@
 package hu.netsurf.erp.usermanagement.testobject
 
 import hu.netsurf.erp.common.constant.CommonTestConstants.EMPTY_STRING
+import hu.netsurf.erp.usermanagement.constant.UserTestConstants.INVALID_CURRENT_PASSWORD
 import hu.netsurf.erp.usermanagement.constant.UserTestConstants.INVALID_NEW_PASSWORD
-import hu.netsurf.erp.usermanagement.constant.UserTestConstants.INVALID_PASSWORD
 import hu.netsurf.erp.usermanagement.constant.UserTestConstants.NEW_PASSWORD
 import hu.netsurf.erp.usermanagement.constant.UserTestConstants.PASSWORD
 import hu.netsurf.erp.usermanagement.input.UpdateUserPasswordInput
@@ -17,7 +17,8 @@ class UpdateUserPasswordInputTestObject {
 
         fun userInput1WithEmptyConfirmNewPassword(): UpdateUserPasswordInput = build(confirmNewPassword = EMPTY_STRING)
 
-        fun updateUserPasswordInput1WithInvalidCurrentPassword(): UpdateUserPasswordInput = build(currentPassword = INVALID_PASSWORD)
+        fun updateUserPasswordInput1WithInvalidCurrentPassword(): UpdateUserPasswordInput =
+            build(currentPassword = INVALID_CURRENT_PASSWORD)
 
         fun updateUserPasswordInput1WithNewPasswordAndPasswordInDatabaseMatches(): UpdateUserPasswordInput = build(newPassword = PASSWORD)
 

--- a/src/test/kotlin/hu/netsurf/erp/usermanagement/testobject/UserInputTestObject.kt
+++ b/src/test/kotlin/hu/netsurf/erp/usermanagement/testobject/UserInputTestObject.kt
@@ -9,7 +9,6 @@ import hu.netsurf.erp.usermanagement.constant.UserTestConstants.LAST_NAME_1
 import hu.netsurf.erp.usermanagement.constant.UserTestConstants.LONG_EMAIL_1
 import hu.netsurf.erp.usermanagement.constant.UserTestConstants.LONG_FIRST_NAME_1
 import hu.netsurf.erp.usermanagement.constant.UserTestConstants.LONG_LAST_NAME_1
-import hu.netsurf.erp.usermanagement.constant.UserTestConstants.LONG_PASSWORD
 import hu.netsurf.erp.usermanagement.constant.UserTestConstants.LONG_USERNAME_1
 import hu.netsurf.erp.usermanagement.constant.UserTestConstants.PASSWORD
 import hu.netsurf.erp.usermanagement.constant.UserTestConstants.USERNAME_1
@@ -26,10 +25,6 @@ class UserInputTestObject {
         fun userInput1WithLongUsername(): UserInput = build(username = LONG_USERNAME_1)
 
         fun userInput1WithEmptyPassword(): UserInput = build(password = EMPTY_STRING)
-
-        fun userInput1WithShortPassword(): UserInput = build(password = "p")
-
-        fun userInput1WithLongPassword(): UserInput = build(password = LONG_PASSWORD)
 
         fun userInput1WithEmptyConfirmPassword(): UserInput = build(confirmPassword = EMPTY_STRING)
 

--- a/src/test/kotlin/hu/netsurf/erp/usermanagement/util/UserInputValidatorTests.kt
+++ b/src/test/kotlin/hu/netsurf/erp/usermanagement/util/UserInputValidatorTests.kt
@@ -14,6 +14,7 @@ import hu.netsurf.erp.usermanagement.constant.UserTestConstants.USERNAME_1
 import hu.netsurf.erp.usermanagement.exception.InvalidEmailAddressFormatException
 import hu.netsurf.erp.usermanagement.exception.InvalidFirstNameFormatException
 import hu.netsurf.erp.usermanagement.exception.InvalidLastNameFormatException
+import hu.netsurf.erp.usermanagement.exception.InvalidPasswordFormatException
 import hu.netsurf.erp.usermanagement.exception.PasswordAndConfirmPasswordNotMatchesException
 import hu.netsurf.erp.usermanagement.input.UserInput
 import hu.netsurf.erp.usermanagement.testobject.UserInputTestObject.Companion.userInput1
@@ -28,12 +29,10 @@ import hu.netsurf.erp.usermanagement.testobject.UserInputTestObject.Companion.us
 import hu.netsurf.erp.usermanagement.testobject.UserInputTestObject.Companion.userInput1WithLongEmail
 import hu.netsurf.erp.usermanagement.testobject.UserInputTestObject.Companion.userInput1WithLongFirstName
 import hu.netsurf.erp.usermanagement.testobject.UserInputTestObject.Companion.userInput1WithLongLastName
-import hu.netsurf.erp.usermanagement.testobject.UserInputTestObject.Companion.userInput1WithLongPassword
 import hu.netsurf.erp.usermanagement.testobject.UserInputTestObject.Companion.userInput1WithLongUsername
 import hu.netsurf.erp.usermanagement.testobject.UserInputTestObject.Companion.userInput1WithShortEmail
 import hu.netsurf.erp.usermanagement.testobject.UserInputTestObject.Companion.userInput1WithShortFirstName
 import hu.netsurf.erp.usermanagement.testobject.UserInputTestObject.Companion.userInput1WithShortLastName
-import hu.netsurf.erp.usermanagement.testobject.UserInputTestObject.Companion.userInput1WithShortPassword
 import hu.netsurf.erp.usermanagement.testobject.UserInputTestObject.Companion.userInput1WithShortUsername
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -63,8 +62,6 @@ class UserInputValidatorTests {
             Stream.of(
                 Arguments.of("username is too short", userInput1WithShortUsername()),
                 Arguments.of("username is too long", userInput1WithLongUsername()),
-                Arguments.of("password is too short", userInput1WithShortPassword()),
-                Arguments.of("password is too long", userInput1WithLongPassword()),
                 Arguments.of("firstName is too short", userInput1WithShortFirstName()),
                 Arguments.of("firstName is too long", userInput1WithLongFirstName()),
                 Arguments.of("lastName is too short", userInput1WithShortLastName()),
@@ -85,6 +82,17 @@ class UserInputValidatorTests {
             Stream.of(
                 Arguments.of("juhász", INVALID_LAST_NAME_STARTS_WITH_LOWERCASE_CHARACTER),
                 Arguments.of("LastNam3", INVALID_LAST_NAME_CONTAINS_DIGIT),
+            )
+
+        @JvmStatic
+        fun invalidPasswordParams(): Stream<Arguments> =
+            Stream.of(
+                Arguments.of("no number", "p@sSwOrD"),
+                Arguments.of("no lowercase character", "P@SSW0RD"),
+                Arguments.of("no uppercase character", "p@ssword"),
+                Arguments.of("no special character", "pAsSwOrD"),
+                Arguments.of("too short", "p"),
+                Arguments.of("too long", "p@sSw0rDp@sSw0rD"),
             )
     }
 
@@ -170,6 +178,27 @@ class UserInputValidatorTests {
     fun `validate test unhappy path - password and confirm password not matches`() {
         assertThrows<PasswordAndConfirmPasswordNotMatchesException> {
             userInputValidator.validate(userInput1WithInvalidConfirmPassword())
+        }
+    }
+
+    @ParameterizedTest(name = "{index} => {0}")
+    @MethodSource("invalidPasswordParams")
+    fun `validate test unhappy path - invalid password format`(
+        testCase: String,
+        password: String,
+    ) {
+        val userInput =
+            UserInput(
+                username = USERNAME_1,
+                password = password,
+                confirmPassword = password,
+                firstName = FIRST_NAME_1,
+                lastName = LAST_NAME_1,
+                email = EMAIL_1,
+            )
+
+        assertThrows<InvalidPasswordFormatException> {
+            userInputValidator.validate(userInput)
         }
     }
 }


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [x] You have successfully built and run unit tests locally
- [x] There are new or updated unit tests validating the changes

### :pencil: Description

When creating a user the password should be between 8 and 15 characters, should contain at least one digit, one uppercase, one lowercase and one special character.