### PR TITLE
Add SecurityConfig to the EnableConfigurationProperties annotation params

### DIFF
--- a/src/main/kotlin/hu/netsurf/erp/Application.kt
+++ b/src/main/kotlin/hu/netsurf/erp/Application.kt
@@ -1,12 +1,18 @@
 package hu.netsurf.erp
 
+import hu.netsurf.erp.usermanagement.config.SecurityConfig
 import hu.netsurf.erp.warehouse.config.FileExtensionsConfig
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
-@EnableConfigurationProperties(value = [FileExtensionsConfig::class])
+@EnableConfigurationProperties(
+    value = [
+        SecurityConfig::class,
+        FileExtensionsConfig::class,
+    ],
+)
 class Application
 
 fun main(args: Array<String>) {


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [x] You have successfully built and run unit tests locally
- [ ] There are new or updated unit tests validating the changes

### :pencil: Description

Adding SecurityConfig to the EnableConfigurationProperties annotation params.