### PR TITLE
Fix password validation vulnerability

### DIFF
--- a/src/main/kotlin/hu/netsurf/erp/usermanagement/exception/NewPasswordAndPasswordInDatabaseMatchesException.kt
+++ b/src/main/kotlin/hu/netsurf/erp/usermanagement/exception/NewPasswordAndPasswordInDatabaseMatchesException.kt
@@ -1,3 +1,0 @@
-package hu.netsurf.erp.usermanagement.exception
-
-class NewPasswordAndPasswordInDatabaseMatchesException : Exception("Nem adható meg új jelszónak a jelenlegi jelszó.")

--- a/src/main/kotlin/hu/netsurf/erp/usermanagement/input/UpdateUserPasswordInput.kt
+++ b/src/main/kotlin/hu/netsurf/erp/usermanagement/input/UpdateUserPasswordInput.kt
@@ -14,7 +14,5 @@ data class UpdateUserPasswordInput(
 
     fun currentPasswordAndPasswordInDatabaseMatches(password: String): Boolean = currentPassword == password
 
-    fun newPasswordAndCurrentPasswordInDatabaseMatches(password: String): Boolean = newPassword == password
-
     fun newPasswordAndConfirmNewPasswordMatches(): Boolean = newPassword == confirmNewPassword
 }

--- a/src/main/kotlin/hu/netsurf/erp/usermanagement/util/UpdateUserPasswordInputValidator.kt
+++ b/src/main/kotlin/hu/netsurf/erp/usermanagement/util/UpdateUserPasswordInputValidator.kt
@@ -3,33 +3,28 @@
 import hu.netsurf.erp.common.exception.EmptyFieldException
 import hu.netsurf.erp.usermanagement.exception.CurrentPasswordAndPasswordInDatabaseNotMatchesException
 import hu.netsurf.erp.usermanagement.exception.NewPasswordAndConfirmNewPasswordNotMatchesException
-import hu.netsurf.erp.usermanagement.exception.NewPasswordAndPasswordInDatabaseMatchesException
 import hu.netsurf.erp.usermanagement.input.UpdateUserPasswordInput
 import org.springframework.stereotype.Component
 
 @Component
 class UpdateUserPasswordInputValidator {
     fun validate(
-        updateUserPasswordInput: UpdateUserPasswordInput,
+        input: UpdateUserPasswordInput,
         passwordInDatabase: String,
     ) {
         if (
-            updateUserPasswordInput.currentPasswordIsEmpty() ||
-            updateUserPasswordInput.newPasswordIsEmpty() ||
-            updateUserPasswordInput.confirmNewPasswordIsEmpty()
+            input.currentPasswordIsEmpty() ||
+            input.newPasswordIsEmpty() ||
+            input.confirmNewPasswordIsEmpty()
         ) {
             throw EmptyFieldException()
         }
 
-        if (!updateUserPasswordInput.currentPasswordAndPasswordInDatabaseMatches(passwordInDatabase)) {
+        if (!input.currentPasswordAndPasswordInDatabaseMatches(passwordInDatabase)) {
             throw CurrentPasswordAndPasswordInDatabaseNotMatchesException()
         }
 
-        if (updateUserPasswordInput.newPasswordAndCurrentPasswordInDatabaseMatches(passwordInDatabase)) {
-            throw NewPasswordAndPasswordInDatabaseMatchesException()
-        }
-
-        if (!updateUserPasswordInput.newPasswordAndConfirmNewPasswordMatches()) {
+        if (!input.newPasswordAndConfirmNewPasswordMatches()) {
             throw NewPasswordAndConfirmNewPasswordNotMatchesException()
         }
     }

--- a/src/test/kotlin/hu/netsurf/erp/usermanagement/controller/UserControllerTests.kt
+++ b/src/test/kotlin/hu/netsurf/erp/usermanagement/controller/UserControllerTests.kt
@@ -1,9 +1,6 @@
 package hu.netsurf.erp.usermanagement.controller
 
 import hu.netsurf.erp.usermanagement.service.UserService
-import hu.netsurf.erp.usermanagement.testobject.CreateUserInputTestObject.Companion.input1
-import hu.netsurf.erp.usermanagement.testobject.DeleteUserInputTestObject.Companion.deleteUserInput1
-import hu.netsurf.erp.usermanagement.testobject.UpdateUserPasswordInputTestObject.Companion.updateUserPasswordInput1
 import hu.netsurf.erp.usermanagement.testobject.UserTestObject.Companion.user1
 import hu.netsurf.erp.usermanagement.testobject.UserTestObject.Companion.user2
 import hu.netsurf.erp.usermanagement.util.UpdateUserPasswordInputSanitizer
@@ -16,6 +13,9 @@ import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import hu.netsurf.erp.usermanagement.testobject.CreateUserInputTestObject.Companion.input1 as createUserInput1
+import hu.netsurf.erp.usermanagement.testobject.DeleteUserInputTestObject.Companion.input1 as deleteUserInput1
+import hu.netsurf.erp.usermanagement.testobject.UpdateUserPasswordInputTestObject.Companion.input1 as updateUserPasswordInput1
 
 class UserControllerTests {
     private val userService: UserService = mockk()
@@ -46,13 +46,13 @@ class UserControllerTests {
     fun `createUser test happy path`() {
         every {
             userInputSanitizer.sanitize(any())
-        } returns input1()
+        } returns createUserInput1()
         justRun { userInputValidator.validate(any()) }
         every {
             userService.createUser(any())
         } returns user1()
 
-        val result = userController.createUser(input1())
+        val result = userController.createUser(createUserInput1())
         assertEquals(user1(), result)
     }
 

--- a/src/test/kotlin/hu/netsurf/erp/usermanagement/testobject/DeleteUserInputTestObject.kt
+++ b/src/test/kotlin/hu/netsurf/erp/usermanagement/testobject/DeleteUserInputTestObject.kt
@@ -4,7 +4,7 @@ import hu.netsurf.erp.usermanagement.input.DeleteUserInput
 
 class DeleteUserInputTestObject {
     companion object {
-        fun deleteUserInput1(): DeleteUserInput = build()
+        fun input1(): DeleteUserInput = build()
 
         private fun build(userId: Int = 1): DeleteUserInput = DeleteUserInput(userId = userId)
     }

--- a/src/test/kotlin/hu/netsurf/erp/usermanagement/testobject/UpdateUserPasswordInputTestObject.kt
+++ b/src/test/kotlin/hu/netsurf/erp/usermanagement/testobject/UpdateUserPasswordInputTestObject.kt
@@ -9,21 +9,17 @@ import hu.netsurf.erp.usermanagement.input.UpdateUserPasswordInput
 
 class UpdateUserPasswordInputTestObject {
     companion object {
-        fun updateUserPasswordInput1(): UpdateUserPasswordInput = build()
+        fun input1(): UpdateUserPasswordInput = build()
 
-        fun userInput1WithEmptyCurrentPassword(): UpdateUserPasswordInput = build(currentPassword = EMPTY_STRING)
+        fun input1WithEmptyCurrentPassword(): UpdateUserPasswordInput = build(currentPassword = EMPTY_STRING)
 
-        fun userInput1WithEmptyNewPassword(): UpdateUserPasswordInput = build(newPassword = EMPTY_STRING)
+        fun input1WithEmptyNewPassword(): UpdateUserPasswordInput = build(newPassword = EMPTY_STRING)
 
-        fun userInput1WithEmptyConfirmNewPassword(): UpdateUserPasswordInput = build(confirmNewPassword = EMPTY_STRING)
+        fun input1WithEmptyConfirmNewPassword(): UpdateUserPasswordInput = build(confirmNewPassword = EMPTY_STRING)
 
-        fun updateUserPasswordInput1WithInvalidCurrentPassword(): UpdateUserPasswordInput =
-            build(currentPassword = INVALID_CURRENT_PASSWORD)
+        fun input1WithInvalidCurrentPassword(): UpdateUserPasswordInput = build(currentPassword = INVALID_CURRENT_PASSWORD)
 
-        fun updateUserPasswordInput1WithNewPasswordAndPasswordInDatabaseMatches(): UpdateUserPasswordInput = build(newPassword = PASSWORD)
-
-        fun updateUserPasswordInput1WithInvalidConfirmNewPassword(): UpdateUserPasswordInput =
-            build(confirmNewPassword = INVALID_NEW_PASSWORD)
+        fun input1WithInvalidConfirmNewPassword(): UpdateUserPasswordInput = build(confirmNewPassword = INVALID_NEW_PASSWORD)
 
         private fun build(
             userId: Int = 1,

--- a/src/test/kotlin/hu/netsurf/erp/usermanagement/util/UpdateUserPasswordInputValidatorTests.kt
+++ b/src/test/kotlin/hu/netsurf/erp/usermanagement/util/UpdateUserPasswordInputValidatorTests.kt
@@ -4,15 +4,13 @@ import hu.netsurf.erp.common.exception.EmptyFieldException
 import hu.netsurf.erp.usermanagement.constant.UserTestConstants.PASSWORD
 import hu.netsurf.erp.usermanagement.exception.CurrentPasswordAndPasswordInDatabaseNotMatchesException
 import hu.netsurf.erp.usermanagement.exception.NewPasswordAndConfirmNewPasswordNotMatchesException
-import hu.netsurf.erp.usermanagement.exception.NewPasswordAndPasswordInDatabaseMatchesException
 import hu.netsurf.erp.usermanagement.input.UpdateUserPasswordInput
-import hu.netsurf.erp.usermanagement.testobject.UpdateUserPasswordInputTestObject.Companion.updateUserPasswordInput1
-import hu.netsurf.erp.usermanagement.testobject.UpdateUserPasswordInputTestObject.Companion.updateUserPasswordInput1WithInvalidConfirmNewPassword
-import hu.netsurf.erp.usermanagement.testobject.UpdateUserPasswordInputTestObject.Companion.updateUserPasswordInput1WithInvalidCurrentPassword
-import hu.netsurf.erp.usermanagement.testobject.UpdateUserPasswordInputTestObject.Companion.updateUserPasswordInput1WithNewPasswordAndPasswordInDatabaseMatches
-import hu.netsurf.erp.usermanagement.testobject.UpdateUserPasswordInputTestObject.Companion.userInput1WithEmptyConfirmNewPassword
-import hu.netsurf.erp.usermanagement.testobject.UpdateUserPasswordInputTestObject.Companion.userInput1WithEmptyCurrentPassword
-import hu.netsurf.erp.usermanagement.testobject.UpdateUserPasswordInputTestObject.Companion.userInput1WithEmptyNewPassword
+import hu.netsurf.erp.usermanagement.testobject.UpdateUserPasswordInputTestObject.Companion.input1
+import hu.netsurf.erp.usermanagement.testobject.UpdateUserPasswordInputTestObject.Companion.input1WithEmptyConfirmNewPassword
+import hu.netsurf.erp.usermanagement.testobject.UpdateUserPasswordInputTestObject.Companion.input1WithEmptyCurrentPassword
+import hu.netsurf.erp.usermanagement.testobject.UpdateUserPasswordInputTestObject.Companion.input1WithEmptyNewPassword
+import hu.netsurf.erp.usermanagement.testobject.UpdateUserPasswordInputTestObject.Companion.input1WithInvalidConfirmNewPassword
+import hu.netsurf.erp.usermanagement.testobject.UpdateUserPasswordInputTestObject.Companion.input1WithInvalidCurrentPassword
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -29,16 +27,16 @@ class UpdateUserPasswordInputValidatorTests {
         @JvmStatic
         fun updateUserPasswordInputEmptyFieldParams(): Stream<Arguments> =
             Stream.of(
-                Arguments.of("current password is empty", userInput1WithEmptyCurrentPassword()),
-                Arguments.of("new password is empty", userInput1WithEmptyNewPassword()),
-                Arguments.of("confirm new password is empty", userInput1WithEmptyConfirmNewPassword()),
+                Arguments.of("current password is empty", input1WithEmptyCurrentPassword()),
+                Arguments.of("new password is empty", input1WithEmptyNewPassword()),
+                Arguments.of("confirm new password is empty", input1WithEmptyConfirmNewPassword()),
             )
     }
 
     @Test
     fun `validate test happy path`() {
         assertDoesNotThrow {
-            updateUserPasswordInputValidator.validate(updateUserPasswordInput1(), passwordInDatabase)
+            updateUserPasswordInputValidator.validate(input1(), passwordInDatabase)
         }
     }
 
@@ -56,30 +54,14 @@ class UpdateUserPasswordInputValidatorTests {
     @Test
     fun `validate test unhappy path - current password and password in database not matches`() {
         assertThrows<CurrentPasswordAndPasswordInDatabaseNotMatchesException> {
-            updateUserPasswordInputValidator.validate(
-                updateUserPasswordInput1WithInvalidCurrentPassword(),
-                passwordInDatabase,
-            )
-        }
-    }
-
-    @Test
-    fun `validate test unhappy path - new password and password in database matches`() {
-        assertThrows<NewPasswordAndPasswordInDatabaseMatchesException> {
-            updateUserPasswordInputValidator.validate(
-                updateUserPasswordInput1WithNewPasswordAndPasswordInDatabaseMatches(),
-                passwordInDatabase,
-            )
+            updateUserPasswordInputValidator.validate(input1WithInvalidCurrentPassword(), passwordInDatabase)
         }
     }
 
     @Test
     fun `validate test unhappy path - new password and confirm new password not matches`() {
         assertThrows<NewPasswordAndConfirmNewPasswordNotMatchesException> {
-            updateUserPasswordInputValidator.validate(
-                updateUserPasswordInput1WithInvalidConfirmNewPassword(),
-                passwordInDatabase,
-            )
+            updateUserPasswordInputValidator.validate(input1WithInvalidConfirmNewPassword(), passwordInDatabase)
         }
     }
 }


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [x] You have successfully built and run unit tests locally
- [x] There are new or updated unit tests validating the changes

### :pencil: Description

Removing validation for checking the new password is matching with the current password in database or not: this is a vulnerability that can lead to someone guess other user's password.