### PR TITLE
Apply password constrains validation when updating password and decoding when checking the current password with the one in database

### DIFF
--- a/src/main/kotlin/hu/netsurf/erp/usermanagement/input/UpdateUserPasswordInput.kt
+++ b/src/main/kotlin/hu/netsurf/erp/usermanagement/input/UpdateUserPasswordInput.kt
@@ -1,5 +1,7 @@
 package hu.netsurf.erp.usermanagement.input
 
+import hu.netsurf.erp.usermanagement.constant.RegexPatterns.PASSWORD_REGEX
+
 data class UpdateUserPasswordInput(
     val userId: Int,
     val currentPassword: String,
@@ -12,7 +14,7 @@ data class UpdateUserPasswordInput(
 
     fun confirmNewPasswordIsEmpty(): Boolean = confirmNewPassword.isEmpty()
 
-    fun currentPasswordAndPasswordInDatabaseMatches(password: String): Boolean = currentPassword == password
+    fun newPasswordIsValid(): Boolean = newPassword.matches(Regex(PASSWORD_REGEX))
 
     fun newPasswordAndConfirmNewPasswordMatches(): Boolean = newPassword == confirmNewPassword
 }

--- a/src/main/kotlin/hu/netsurf/erp/usermanagement/service/UserService.kt
+++ b/src/main/kotlin/hu/netsurf/erp/usermanagement/service/UserService.kt
@@ -67,7 +67,7 @@ class UserService(
             throw UserNotFoundException(user.id)
         }
 
-        user.password = newPassword
+        user.password = passwordUtil.encode(newPassword)
         val updatedUser = userRepository.save(user)
 
         logger.logInfo(

--- a/src/main/kotlin/hu/netsurf/erp/usermanagement/util/PasswordUtil.kt
+++ b/src/main/kotlin/hu/netsurf/erp/usermanagement/util/PasswordUtil.kt
@@ -9,10 +9,8 @@ class PasswordUtil(
 ) {
     fun encode(rawPassword: String): String = passwordEncoder.encode(rawPassword)
 
-    // For login.
-
-    /*fun verify(
+    fun verify(
         rawPassword: String,
         hashedPassword: String,
-    ): Boolean = passwordEncoder.matches(rawPassword, hashedPassword)*/
+    ): Boolean = passwordEncoder.matches(rawPassword, hashedPassword)
 }

--- a/src/main/kotlin/hu/netsurf/erp/usermanagement/util/UpdateUserPasswordInputValidator.kt
+++ b/src/main/kotlin/hu/netsurf/erp/usermanagement/util/UpdateUserPasswordInputValidator.kt
@@ -2,12 +2,15 @@
 
 import hu.netsurf.erp.common.exception.EmptyFieldException
 import hu.netsurf.erp.usermanagement.exception.CurrentPasswordAndPasswordInDatabaseNotMatchesException
+import hu.netsurf.erp.usermanagement.exception.InvalidPasswordFormatException
 import hu.netsurf.erp.usermanagement.exception.NewPasswordAndConfirmNewPasswordNotMatchesException
 import hu.netsurf.erp.usermanagement.input.UpdateUserPasswordInput
 import org.springframework.stereotype.Component
 
 @Component
-class UpdateUserPasswordInputValidator {
+class UpdateUserPasswordInputValidator(
+    private val passwordUtil: PasswordUtil,
+) {
     fun validate(
         input: UpdateUserPasswordInput,
         passwordInDatabase: String,
@@ -20,7 +23,11 @@ class UpdateUserPasswordInputValidator {
             throw EmptyFieldException()
         }
 
-        if (!input.currentPasswordAndPasswordInDatabaseMatches(passwordInDatabase)) {
+        if (!input.newPasswordIsValid()) {
+            throw InvalidPasswordFormatException()
+        }
+
+        if (!passwordUtil.verify(input.currentPassword, passwordInDatabase)) {
             throw CurrentPasswordAndPasswordInDatabaseNotMatchesException()
         }
 

--- a/src/test/kotlin/hu/netsurf/erp/usermanagement/constant/UserTestConstants.kt
+++ b/src/test/kotlin/hu/netsurf/erp/usermanagement/constant/UserTestConstants.kt
@@ -2,7 +2,7 @@ package hu.netsurf.erp.usermanagement.constant
 
 object UserTestConstants {
     const val PASSWORD = "p@sSw0rD"
-    const val NEW_PASSWORD = "NeWpAsSwOrD"
+    const val NEW_PASSWORD = "NeWp@sSw0rD"
     const val INVALID_CURRENT_PASSWORD = "pAsSwOrD1"
     const val INVALID_CONFIRM_PASSWORD = "CoNfIrMpAsSwOrD"
     const val INVALID_NEW_PASSWORD = "NeWpAsSwOrD1"

--- a/src/test/kotlin/hu/netsurf/erp/usermanagement/service/UserServiceTests.kt
+++ b/src/test/kotlin/hu/netsurf/erp/usermanagement/service/UserServiceTests.kt
@@ -89,6 +89,9 @@ class UserServiceTests {
     @Test
     fun `updateUserPassword test happy path`() {
         every {
+            passwordUtil.encode(any())
+        } returns HASHED_PASSWORD
+        every {
             userRepository.save(any())
         } returns user1()
 

--- a/src/test/kotlin/hu/netsurf/erp/usermanagement/util/PasswordUtilTests.kt
+++ b/src/test/kotlin/hu/netsurf/erp/usermanagement/util/PasswordUtilTests.kt
@@ -5,6 +5,8 @@ import hu.netsurf.erp.usermanagement.constant.UserTestConstants.PASSWORD
 import io.mockk.coEvery
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.security.crypto.password.PasswordEncoder
 
@@ -20,5 +22,25 @@ class PasswordUtilTests {
 
         val result = passwordUtil.encode(PASSWORD)
         assertEquals(HASHED_PASSWORD, result)
+    }
+
+    @Test
+    fun `verify test happy path`() {
+        coEvery {
+            passwordEncoder.matches(any(), any())
+        } returns true
+
+        val result = passwordUtil.verify(PASSWORD, HASHED_PASSWORD)
+        assertTrue(result)
+    }
+
+    @Test
+    fun `verify test unhappy path`() {
+        coEvery {
+            passwordEncoder.matches(any(), any())
+        } returns false
+
+        val result = passwordUtil.verify(PASSWORD, HASHED_PASSWORD)
+        assertFalse(result)
     }
 }


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [x] You have successfully built and run unit tests locally
- [x] There are new or updated unit tests validating the changes

### :pencil: Description

Applying password constrains validation when updating user's password. Decoding the current password in database when checking the current password coming in the input for equality check.