### PR TITLE
Refactor product photo upload

### DIFF
--- a/src/main/kotlin/hu/netsurf/erp/warehouse/constant/FileConstants.kt
+++ b/src/main/kotlin/hu/netsurf/erp/warehouse/constant/FileConstants.kt
@@ -5,4 +5,5 @@ object FileConstants {
     const val PHOTOS_SUBDIRECTORY_NAME = "photos"
     const val PRODUCTS_SUBDIRECTORY_NAME = "products"
     const val IMAGE = "image"
+    const val PRODUCT_PHOTO = "productPhoto"
 }

--- a/src/main/kotlin/hu/netsurf/erp/warehouse/controller/ProductPhotoController.kt
+++ b/src/main/kotlin/hu/netsurf/erp/warehouse/controller/ProductPhotoController.kt
@@ -89,7 +89,7 @@ class ProductPhotoController(
     }
 
     @PostMapping(path = ["/upload/{productId}"])
-    fun createProductPhoto(
+    fun uploadProductPhoto(
         @PathVariable productId: Int,
         @RequestParam("file") file: MultipartFile,
     ): ResponseEntity<*> {

--- a/src/main/kotlin/hu/netsurf/erp/warehouse/controller/ProductPhotoController.kt
+++ b/src/main/kotlin/hu/netsurf/erp/warehouse/controller/ProductPhotoController.kt
@@ -4,6 +4,7 @@ import hu.netsurf.erp.common.exception.NotFoundException
 import hu.netsurf.erp.common.extension.logError
 import hu.netsurf.erp.common.extension.logInfo
 import hu.netsurf.erp.warehouse.constant.FileConstants.IMAGE
+import hu.netsurf.erp.warehouse.constant.FileConstants.PRODUCT_PHOTO
 import hu.netsurf.erp.warehouse.constant.LogEventConstants.GET_PRODUCT_PHOTO_FAILURE_RESPONSE
 import hu.netsurf.erp.warehouse.constant.LogEventConstants.GET_PRODUCT_PHOTO_REQUEST_RECEIVED
 import hu.netsurf.erp.warehouse.constant.LogEventConstants.GET_PRODUCT_PHOTO_SUCCESS_RESPONSE
@@ -91,7 +92,7 @@ class ProductPhotoController(
     fun createProductPhoto(
         @PathVariable productId: Int,
         @RequestParam("file") file: MultipartFile,
-    ): ResponseEntity<String> {
+    ): ResponseEntity<*> {
         try {
             logger.logInfo(
                 UPLOAD_PRODUCT_PHOTO_REQUEST_RECEIVED,
@@ -111,19 +112,19 @@ class ProductPhotoController(
                 ),
             )
 
-            val productPhotoFileName = productPhotoService.uploadProductPhoto(productId, photoFile)
+            val productPhotoFileName = productPhotoService.uploadProductPhoto(productId, photoFile).toString()
 
             logger.logInfo(
                 UPLOAD_PRODUCT_PHOTO_SUCCESS_RESPONSE,
                 mapOf(
                     PRODUCT_ID to productId,
-                    PRODUCT_PHOTO_FILE_NAME to productPhotoFileName.toString(),
+                    PRODUCT_PHOTO_FILE_NAME to productPhotoFileName,
                 ),
             )
 
             return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .body(productPhotoFileName)
+                .body(mapOf(PRODUCT_PHOTO to productPhotoFileName))
         } catch (exception: NotFoundException) {
             logger.logError(UPLOAD_PRODUCT_PHOTO_FAILURE_RESPONSE, exception)
 

--- a/src/test/kotlin/hu/netsurf/erp/warehouse/constant/PhotoTestConstants.kt
+++ b/src/test/kotlin/hu/netsurf/erp/warehouse/constant/PhotoTestConstants.kt
@@ -14,6 +14,7 @@ object PhotoTestConstants {
     const val FILE_NAME_PNG = "file_name.$PNG"
     const val FILE_NAME_BMP = "file_name.$BMP"
     const val INVALID_FILE_NAME = "file_name.txt"
+    const val PRODUCT_PHOTO = "productPhoto"
     const val PHOTO_FILE_NAME = "7a759fbb-39d8-4b3b-af57-4266980901dc.jpeg"
     const val PHOTO_FILE_AS_STRING = "{originalFileName=$JPEG size=$FILE_SIZE contentType=$CONTENT_TYPE_IMAGE_JPEG}"
     const val UPLOADS_DIRECTORY_WITH_PHOTOS_SUBDIRECTORY_AND_CUSTOM_SUBDIRECTORY = "uploads/photos/products/"

--- a/src/test/kotlin/hu/netsurf/erp/warehouse/controller/ProductPhotoControllerTests.kt
+++ b/src/test/kotlin/hu/netsurf/erp/warehouse/controller/ProductPhotoControllerTests.kt
@@ -3,6 +3,7 @@ package hu.netsurf.erp.warehouse.controller
 import hu.netsurf.erp.warehouse.constant.PhotoTestConstants.CONTENT_TYPE_IMAGE_JPEG
 import hu.netsurf.erp.warehouse.constant.PhotoTestConstants.FILE_SIZE
 import hu.netsurf.erp.warehouse.constant.PhotoTestConstants.PHOTO_FILE_NAME
+import hu.netsurf.erp.warehouse.constant.PhotoTestConstants.PRODUCT_PHOTO
 import hu.netsurf.erp.warehouse.exception.ProductAlreadyHasPhotoUploadedException
 import hu.netsurf.erp.warehouse.exception.ProductNotFoundException
 import hu.netsurf.erp.warehouse.exception.ProductPhotoNotFoundException
@@ -59,34 +60,34 @@ class ProductPhotoControllerTests {
     }
 
     @Test
-    fun `createProductPhoto test happy path`() {
+    fun `uploadProductPhoto test happy path`() {
         every {
             productPhotoService.uploadProductPhoto(any(), any())
         } returns PHOTO_FILE_NAME
 
-        val result = productPhotoController.createProductPhoto(1, multipartFile())
+        val result = productPhotoController.uploadProductPhoto(1, multipartFile())
         assertEquals(HttpStatus.CREATED, result.statusCode)
-        assertEquals(PHOTO_FILE_NAME, result.body)
+        assertEquals(mapOf(PRODUCT_PHOTO to PHOTO_FILE_NAME), result.body)
     }
 
     @Test
-    fun `createProductPhoto test unhappy path - product not found (HTTP 404)`() {
+    fun `uploadProductPhoto test unhappy path - product not found (HTTP 404)`() {
         every {
             productPhotoService.uploadProductPhoto(any(), any())
         } throws ProductNotFoundException(3)
 
-        val result = productPhotoController.createProductPhoto(3, multipartFile())
+        val result = productPhotoController.uploadProductPhoto(3, multipartFile())
         assertEquals(HttpStatus.NOT_FOUND, result.statusCode)
         assertEquals("Termék a következő azonosítóval: #3 nem található.", result.body)
     }
 
     @Test
-    fun `createProductPhoto test unhappy path - product already has photo uploaded (HTTP 400)`() {
+    fun `uploadProductPhoto test unhappy path - product already has photo uploaded (HTTP 400)`() {
         every {
             productPhotoService.uploadProductPhoto(any(), any())
         } throws ProductAlreadyHasPhotoUploadedException(1)
 
-        val result = productPhotoController.createProductPhoto(1, multipartFile())
+        val result = productPhotoController.uploadProductPhoto(1, multipartFile())
         assertEquals(HttpStatus.BAD_REQUEST, result.statusCode)
         assertEquals(
             "Termék a következő azonosítóval: #1 már rendelkezik feltöltött fényképpel.",


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [x] You have successfully built and run unit tests locally
- [x] There are new or updated unit tests validating the changes

### :pencil: Description

Returning a key-value pair respone when uploading a product photo. Renaming 'createProductPhoto' function to 'uploadProductPhoto'.