### PR TITLE
Move InvalidEmailAddressFormatException to the common exceptions package

### DIFF
--- a/src/main/kotlin/hu/netsurf/erp/common/exception/InvalidEmailAddressFormatException.kt
+++ b/src/main/kotlin/hu/netsurf/erp/common/exception/InvalidEmailAddressFormatException.kt
@@ -1,3 +1,3 @@
-package hu.netsurf.erp.usermanagement.exception
+package hu.netsurf.erp.common.exception
 
 class InvalidEmailAddressFormatException : Exception("Nem megfelelő e-mail cím formátum.")

--- a/src/main/kotlin/hu/netsurf/erp/usermanagement/util/validation/CreateUserInputValidator.kt
+++ b/src/main/kotlin/hu/netsurf/erp/usermanagement/util/validation/CreateUserInputValidator.kt
@@ -1,8 +1,8 @@
 ﻿package hu.netsurf.erp.usermanagement.util.validation
 
 import hu.netsurf.erp.common.exception.EmptyFieldException
+import hu.netsurf.erp.common.exception.InvalidEmailAddressFormatException
 import hu.netsurf.erp.common.exception.InvalidLengthException
-import hu.netsurf.erp.usermanagement.exception.InvalidEmailAddressFormatException
 import hu.netsurf.erp.usermanagement.exception.InvalidFirstNameFormatException
 import hu.netsurf.erp.usermanagement.exception.InvalidLastNameFormatException
 import hu.netsurf.erp.usermanagement.input.CreateUserInput

--- a/src/main/kotlin/hu/netsurf/erp/warehouse/util/validation/CreateSupplierInputValidator.kt
+++ b/src/main/kotlin/hu/netsurf/erp/warehouse/util/validation/CreateSupplierInputValidator.kt
@@ -1,8 +1,8 @@
 ﻿package hu.netsurf.erp.warehouse.util.validation
 
 import hu.netsurf.erp.common.exception.EmptyFieldException
+import hu.netsurf.erp.common.exception.InvalidEmailAddressFormatException
 import hu.netsurf.erp.common.exception.InvalidLengthException
-import hu.netsurf.erp.usermanagement.exception.InvalidEmailAddressFormatException
 import hu.netsurf.erp.warehouse.input.CreateSupplierInput
 import org.springframework.stereotype.Component
 

--- a/src/test/kotlin/hu/netsurf/erp/usermanagement/util/validation/CreateUserInputValidatorTests.kt
+++ b/src/test/kotlin/hu/netsurf/erp/usermanagement/util/validation/CreateUserInputValidatorTests.kt
@@ -1,6 +1,7 @@
 package hu.netsurf.erp.usermanagement.util.validation
 
 import hu.netsurf.erp.common.exception.EmptyFieldException
+import hu.netsurf.erp.common.exception.InvalidEmailAddressFormatException
 import hu.netsurf.erp.common.exception.InvalidLengthException
 import hu.netsurf.erp.usermanagement.constant.UserTestConstants.EMAIL_1
 import hu.netsurf.erp.usermanagement.constant.UserTestConstants.FIRST_NAME_1
@@ -9,7 +10,6 @@ import hu.netsurf.erp.usermanagement.constant.UserTestConstants.INVALID_FIRST_NA
 import hu.netsurf.erp.usermanagement.constant.UserTestConstants.INVALID_LAST_NAME_CONTAINS_DIGIT
 import hu.netsurf.erp.usermanagement.constant.UserTestConstants.INVALID_LAST_NAME_STARTS_WITH_LOWERCASE_CHARACTER
 import hu.netsurf.erp.usermanagement.constant.UserTestConstants.LAST_NAME_1
-import hu.netsurf.erp.usermanagement.exception.InvalidEmailAddressFormatException
 import hu.netsurf.erp.usermanagement.exception.InvalidFirstNameFormatException
 import hu.netsurf.erp.usermanagement.exception.InvalidLastNameFormatException
 import hu.netsurf.erp.usermanagement.input.CreateUserInput

--- a/src/test/kotlin/hu/netsurf/erp/warehouse/util/validation/CreateSupplierInputValidatorTests.kt
+++ b/src/test/kotlin/hu/netsurf/erp/warehouse/util/validation/CreateSupplierInputValidatorTests.kt
@@ -1,8 +1,8 @@
 package hu.netsurf.erp.warehouse.util.validation
 
 import hu.netsurf.erp.common.exception.EmptyFieldException
+import hu.netsurf.erp.common.exception.InvalidEmailAddressFormatException
 import hu.netsurf.erp.common.exception.InvalidLengthException
-import hu.netsurf.erp.usermanagement.exception.InvalidEmailAddressFormatException
 import hu.netsurf.erp.warehouse.input.CreateSupplierInput
 import hu.netsurf.erp.warehouse.testobject.CreateSupplierInputTestObject.Companion.input1
 import hu.netsurf.erp.warehouse.testobject.CreateSupplierInputTestObject.Companion.input1WithEmptyName


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [x] You have successfully built and run unit tests locally
- [x] There are new or updated unit tests validating the changes

### :pencil: Description

Moving InvalidEmailAddressFormatException to the common exceptions package.